### PR TITLE
docs(getting-started): correct spelling of BootstrapVue

### DIFF
--- a/apps/docs/docs/getting-started/README.md
+++ b/apps/docs/docs/getting-started/README.md
@@ -207,7 +207,7 @@ Enjoy it in your app without import.
 </template>
 ```
 
-## Comparison with BoostrapVue
+## Comparison with BootstrapVue
 
 BootstrapVue is the parent project for which this is based on. We consider BootstrapVue as the best implementation of Bootstrap `v4`. We strive for a full compatibility list for BootstrapVue. However, due to the nature of the rewrite, some features may be missing or changed. If anyone has spotted a missing compatibility feature, we request that you submit a GitHub issue.
 


### PR DESCRIPTION
# Describe the PR

Fixing a small typo in the docs to correctly spell BootstrapVue.

## PR checklist

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix :bug: - `fix(...)`
- [ ] Feature - `feat(...)`
- [ ] ARIA accessibility - `fix(...)`
- [x] Documentation update - `docs(...)`
- [ ] Other (please describe)

**The PR fulfills these requirements:**

- [x] Pull request title and all commits follow the [**Conventional Commits**](https://www.conventionalcommits.org/) convention or has an [**override**](https://github.com/googleapis/release-please#how-can-i-fix-release-notes) in this pull request body **This is very important, as the `CHANGELOG` is generated from these messages, and determines the next version type. Pull requests that do not follow conventional commits or do not have an override will be denied**
