### PR TITLE
Missing v-b-modal directive

### DIFF
--- a/packages/bootstrap-vue-next/src/directives/exports/index.ts
+++ b/packages/bootstrap-vue-next/src/directives/exports/index.ts
@@ -1,5 +1,6 @@
 export {
   BColorMode as vBColorMode,
+  BModal as vBModal,
   BPopover as vBPopover,
   BToggle as vBToggle,
   BTooltip as vBTooltip,


### PR DESCRIPTION
# Describe the PR

Since version 0.6, the v-b-modal directive is not working

## Small replication

        <b-button
          v-b-modal.editModal
          >Should open the modal with editModal id
        </b-button>

runtime-core.esm-bundler.js?d2dd:38 [Vue warn]: Failed to resolve directive: b-modal 

## PR checklist

<!-- (Update "[ ]" to "[x]" to check a box) -->
runtime-core.esm-bundler.js?d2dd:38 [Vue warn]: Failed to resolve directive: b-modal 
**What kind of change does this PR introduce?** (check at least one)

- [X] Bugfix :bug: - `fix(...)`
- [ ] Feature - `feat(...)`
- [ ] ARIA accessibility - `fix(...)`
- [ ] Documentation update - `docs(...)`
- [ ] Other (please describe)

**The PR fulfills these requirements:**

- [ ] Pull request title and all commits follow the [**Conventional Commits**](https://www.conventionalcommits.org/) convention or has an [**override**](https://github.com/googleapis/release-please#how-can-i-fix-release-notes) in this pull request body **This is very important, as the `CHANGELOG` is generated from these messages, and determines the next version type. Pull requests that do not follow conventional commits or do not have an override will be denied**
