### PR TITLE
fix(BTabs): add role="presentation"

### DIFF
--- a/packages/bootstrap-vue-next/src/components/BTabs/BTabs.vue
+++ b/packages/bootstrap-vue-next/src/components/BTabs/BTabs.vue
@@ -30,6 +30,7 @@
           :key="idx"
           class="nav-item"
           :class="tab.props['title-item-class']"
+          role="presentation"
         >
           <button
             :id="buttonId"


### PR DESCRIPTION
# Describe the PR

Add `role="presentation"` to the `li` within the B-Tabs component for improved accessibility.

Without this, Microsoft's [Accessibility Insights for Web](https://accessibilityinsights.io/docs/web/overview/) Chrome extension flags an error, as the default role for `li` (listitem) should only be in `ul` or `ol` elements that have no explicit role, or `role="list"`.

## PR checklist

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix :bug: - `fix(...)`
- [ ] Feature - `feat(...)`
- [x] ARIA accessibility - `fix(...)`
- [ ] Documentation update - `docs(...)`
- [ ] Other (please describe)

**The PR fulfills these requirements:**

- [x] Pull request title and all commits follow the [**Conventional Commits**](https://www.conventionalcommits.org/) convention or has an [**override**](https://github.com/googleapis/release-please#how-can-i-fix-release-notes) in this pull request body **This is very important, as the `CHANGELOG` is generated from these messages, and determines the next version type. Pull requests that do not follow conventional commits or do not have an override will be denied**
