### PR TITLE
feat(BAccordion): add header-tag prop on BAccordionItem

### DIFF
--- a/packages/bootstrap-vue-next/src/components/BAccordion/BAccordionItem.vue
+++ b/packages/bootstrap-vue-next/src/components/BAccordion/BAccordionItem.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="accordion-item">
-    <h2 :id="`${computedId}heading`" class="accordion-header">
+    <component :is="headerTag" :id="`${computedId}heading`" class="accordion-header">
       <button
         v-b-toggle:[computedId]
         class="accordion-button"
@@ -13,7 +13,7 @@
           {{ title }}
         </slot>
       </button>
-    </h2>
+    </component>
     <b-collapse
       :id="computedId"
       class="accordion-collapse"
@@ -41,9 +41,13 @@ interface BAccordionItemProps {
   id?: string
   title?: string
   visible?: Booleanish
+  headerTag?: string
 }
 
-const props = withDefaults(defineProps<BAccordionItemProps>(), {visible: false})
+const props = withDefaults(defineProps<BAccordionItemProps>(), {
+  visible: false,
+  headerTag: 'h2',
+})
 
 const parentData = inject(accordionInjectionKey, null)
 

--- a/packages/bootstrap-vue-next/src/components/BAccordion/accordion-item.spec.ts
+++ b/packages/bootstrap-vue-next/src/components/BAccordion/accordion-item.spec.ts
@@ -83,6 +83,20 @@ describe('accordion-item', () => {
     expect($bcollapse.attributes('aria-labelledby')).toBe('headingfoobar')
   })
 
+  it('headerTag is h2 by default', () => {
+    const wrapper = mount(BAccordionItem)
+    const $h2 = wrapper.find('h2')
+    expect($h2.exists()).toBe(true)
+  })
+
+  it('header tag is prop headerTag', () => {
+    const wrapper = mount(BAccordionItem, {
+      props: {headerTag: 'h3'},
+    })
+    const $h3 = wrapper.find('h3')
+    expect($h3.exists()).toBe(true)
+  })
+
   it('h2 child has static class accordion-header', () => {
     const wrapper = mount(BAccordionItem)
     const $h2 = wrapper.get('h2')

--- a/packages/bootstrap-vue-next/src/types/components/BAccordion/BAccordionItem.ts
+++ b/packages/bootstrap-vue-next/src/types/components/BAccordion/BAccordionItem.ts
@@ -3,6 +3,7 @@ export interface Props {
   id?: string
   title?: string
   visible?: boolean
+  headerTag?: string
 }
 // Emits
 


### PR DESCRIPTION
# Describe the PR

Add header-tag prop on BAccordionItem in order to be able to change default `h2` tag for the title.

## PR checklist

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix :bug: - `fix(...)`
- [X] Feature - `feat(...)`
- [ ] ARIA accessibility - `fix(...)`
- [ ] Documentation update - `docs(...)`
- [ ] Other (please describe)

**The PR fulfills these requirements:**

- [X] Pull request title and all commits follow the [**Conventional Commits**](https://www.conventionalcommits.org/) convention or has an [**override**](https://github.com/googleapis/release-please#how-can-i-fix-release-notes) in this pull request body **This is very important, as the `CHANGELOG` is generated from these messages, and determines the next version type. Pull requests that do not follow conventional commits or do not have an override will be denied**
