### PR TITLE
Collapse native vue, no more bs.js!

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,2 @@
+#shamefully-hoist=true
+#strict-peer-dependencies=false

--- a/apps/playground/package.json
+++ b/apps/playground/package.json
@@ -9,14 +9,13 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@popperjs/core": "2.11.6",
-    "bootstrap": "5.2.3",
     "bootstrap-vue-next": "workspace:*",
     "vue": "3.2.45",
     "vue-router": "4.1.6"
   },
   "devDependencies": {
     "@vitejs/plugin-vue": "3.2.0",
+    "bootstrap-styles": "5.2.3",
     "rollup-plugin-visualizer": "5.8.3",
     "tsconfig": "workspace:*",
     "typescript": "4.9.3",

--- a/apps/playground/src/Views/HomePage.vue
+++ b/apps/playground/src/Views/HomePage.vue
@@ -59,6 +59,7 @@ import TBreadcrumb from '../components/Comps/TBreadcrumb.vue'
 import TButton from '../components/Comps/TButton.vue'
 import TCard from '../components/Comps/TCard.vue'
 import TCarousel from '../components/Comps/TCarousel.vue'
+import TCollapse from '../components/Comps/TCollapse.vue'
 import TDropdown from '../components/Comps/TDropdown.vue'
 import TForm from '../components/Comps/TForm.vue'
 import TFormCheckbox from '../components/Comps/TFormCheckbox.vue'
@@ -97,6 +98,7 @@ const comps: {name: string; is: unknown; disabled?: true}[] = [
   {name: 'Button', is: TButton},
   {name: 'Card', is: TCard},
   {name: 'Carousel', is: TCarousel},
+  {name: 'Collapse', is: TCollapse},
   {name: 'Dropdown', is: TDropdown},
   {name: 'Form', is: TForm},
   {name: 'FormCheckbox', is: TFormCheckbox},

--- a/apps/playground/src/components/Comps/TBLink.vue
+++ b/apps/playground/src/components/Comps/TBLink.vue
@@ -2,7 +2,7 @@
   <b-container fluid>
     <b-row>
       <b-col>
-        <b-link :to="{name: 'Home', path: '/' /* path is used when vue-router is not present */}"
+        <b-link :to="{name: 'index', path: '/' /* path is used when vue-router is not present */}"
           >Home</b-link
         >
       </b-col>
@@ -11,7 +11,7 @@
       <b-col>
         <b-link
           :to="{
-            name: 'About',
+            name: 'about',
             params: {id: '456'},
             query: {param: 'someVal'},
             path: '/about' /* path is used when vue-router is not present */,

--- a/apps/playground/src/components/Comps/TCollapse.vue
+++ b/apps/playground/src/components/Comps/TCollapse.vue
@@ -1,0 +1,104 @@
+<template>
+  <b-container>
+    <b-row>
+      <b-col>
+        <b-collapse id="collapse-1" class="mt-2">
+          <template #header="{visible, toggle, id}">
+            <h4>Custom Header</h4>
+            <p>Visible: {{ visible }}</p>
+            <b-button variant="primary" :aria-expanded="visible" :aria-controls="id" @click="toggle"
+              >Toggle</b-button
+            >
+          </template>
+          <b-card>
+            <p class="card-text">Collapse contents Here</p>
+            <b-button v-b-toggle.collapse-1-inner size="sm"
+              >Toggle Inner Collapse with directive</b-button
+            >
+            <b-collapse id="collapse-1-inner" class="mt-2">
+              <b-card>Hello!</b-card>
+            </b-collapse>
+          </b-card>
+        </b-collapse>
+
+        <b-collapse id="collapse-2" visible class="mt-2">
+          <template #header="{visible, toggle}">
+            <h4>Start open</h4>
+            <b-button :variant="visible ? 'secondary' : 'primary'" @click="toggle">Toggle</b-button>
+          </template>
+          <b-card>
+            <p class="card-text">Started open with visible prop</p>
+          </b-card>
+        </b-collapse>
+        <b-collapse id="collapse-2" toggle class="mt-2">
+          <template #header="{toggle}">
+            <h4>Toggled open on load</h4>
+            <b-button variant="primary" @click="toggle">Toggle</b-button>
+          </template>
+          <b-card>
+            <p class="card-text">Openned with animation using toggle prop</p>
+          </b-card>
+        </b-collapse>
+        <div style="min-height: 120px">
+          <b-collapse id="collapse-2" horizontal class="mt-2">
+            <template #header="{toggle}">
+              <b-button variant="primary" @click="toggle">Toggle horizontal</b-button>
+            </template>
+            <b-card style="width: 300px">
+              <p class="card-text">Collapse contents Here</p>
+            </b-card>
+          </b-collapse>
+        </div>
+        <div>
+          <b-button @click="collapseState = !collapseState">Toggle via v-model</b-button>
+          <b-collapse id="collapse-2" v-model="collapseState" class="mt-2">
+            <b-card>
+              <p class="card-text">Collapse contents Here</p>
+            </b-card>
+          </b-collapse>
+        </div>
+        <div>
+          <b-button @click="collapseRef?.toggle()">Toggle via ref</b-button>
+          <b-collapse ref="collapseRef" class="mt-2">
+            <b-card>
+              <p class="card-text">Collapse contents Here</p>
+            </b-card>
+          </b-collapse>
+        </div>
+      </b-col>
+      <b-col>
+        <b-accordion flush>
+          <b-accordion-item id="iddddd" title="Accordion Item #1" visible>
+            Accordion is also using collapse. Openned by visible prop
+          </b-accordion-item>
+
+          <b-accordion-item v-model="collapseState" title="Openned with v-model">
+            <strong>This is the second item's accordion body.</strong> It is hidden by default,
+            until the collapse plugin adds the appropriate classes that we use to style each
+            element. These classes control the overall appearance, as well as the showing and hiding
+            via CSS transitions. You can modify any of this with custom CSS or overriding our
+            default variables. It's also worth noting that just about any HTML can go within the
+            <code>.accordion-body</code>, though the transition does limit overflow.
+          </b-accordion-item>
+
+          <b-accordion-item title="Accordion Item #3">
+            <strong>This is the third item's accordion body.</strong> It is hidden by default, until
+            the collapse plugin adds the appropriate classes that we use to style each element.
+            These classes control the overall appearance, as well as the showing and hiding via CSS
+            transitions. You can modify any of this with custom CSS or overriding our default
+            variables. It's also worth noting that just about any HTML can go within the
+            <code>.accordion-body</code>, though the transition does limit overflow.
+          </b-accordion-item>
+        </b-accordion>
+      </b-col>
+    </b-row>
+  </b-container>
+</template>
+
+<script setup lang="ts">
+// You can use this file as a development spot to test your changes
+// Please do not commit this file
+import {ref} from 'vue'
+const collapseState = ref(true)
+const collapseRef = ref(null as unknown as {toggle: () => void})
+</script>

--- a/apps/playground/src/components/Comps/TDropdown.vue
+++ b/apps/playground/src/components/Comps/TDropdown.vue
@@ -22,6 +22,20 @@
     </b-row>
     <b-row>
       <b-col>
+        <h4 class="m-2">v-model</h4>
+      </b-col>
+    </b-row>
+    <b-row>
+      <b-col>
+        <b-form-checkbox v-model="state"> state</b-form-checkbox>
+
+        <b-dropdown v-model="state" text="using v-model" class="m-2">
+          <b-dropdown-item href="#">Action</b-dropdown-item>
+        </b-dropdown>
+      </b-col>
+    </b-row>
+    <b-row>
+      <b-col>
         <h4 class="m-2">Split & variant</h4>
       </b-col>
     </b-row>
@@ -198,7 +212,7 @@
           <b-dropdown-item to="/">Home</b-dropdown-item>
           <b-dropdown-item
             :to="{
-              name: 'About',
+              name: 'about',
               params: {id: '456'},
               query: {param: 'someVal'},
             }"
@@ -217,5 +231,8 @@
 </template>
 
 <script setup lang="ts">
+import {ref} from 'vue'
+
 const consoleLog = (...args: unknown[]) => console.log(...args)
+const state = ref(true)
 </script>

--- a/apps/playground/src/components/Comps/TModal.vue
+++ b/apps/playground/src/components/Comps/TModal.vue
@@ -3,6 +3,8 @@
     <b-row>
       <b-col>
         <b-button @click="showModal = !showModal">Toggle modal v-model</b-button>
+        <b-button v-b-toggle.exampleModal>Toggle with v-b-toggle directive</b-button>
+        <b-button v-b-modal.exampleModal>Toggle with v-b-modal directive</b-button>
         {{ showModal }}
         <!-- <b-button v-b-modal:exampleModal>Launch demo modal</b-button> -->
         <b-modal

--- a/apps/playground/src/components/Comps/TPopover.vue
+++ b/apps/playground/src/components/Comps/TPopover.vue
@@ -5,7 +5,7 @@
         <b-button id="popover">hover me</b-button>
         <b-popover target="popover" :delay="{show: 400, hide: 5000}" placement="right">
           <template #title>What?</template>
-          <template #content> Hello Word </template>
+          Hello Word
         </b-popover>
         <span ref="popoverContainerRef" class="m-4"> targetRef for popover defined lower. </span>
       </b-col>
@@ -44,35 +44,37 @@
       <b-col>
         <b-popover click :model-value="true" placement="right">
           <template #title> Click </template>
-          <template #content> this should close on click outside </template>
-          <b-button>click</b-button>
+          <template #target>
+            <b-button>click</b-button>
+          </template>
+          this should close on click outside
         </b-popover>
       </b-col>
       <b-col>
         <b-tooltip click>
-          <template #default="{showState}">
+          <template #target="{showState}">
             <b-button :variant="showState ? 'primary' : 'secondary'">
               click tooltip component
             </b-button>
           </template>
-          <template #content> <b>Tooltip</b> content </template>
+          <template #default> <b>Tooltip</b> content </template>
         </b-tooltip>
       </b-col>
     </b-row>
     <b-row class="my-5">
       <b-col>
         <b-popover placement="top">
-          <b-button id="popover-target-1">Hover Me</b-button>
           <template #title>
             Popover
             <em>Title</em>
             - {{ popoverInput }}
           </template>
-          <template #content>
-            <b-button @click="consoleLog('Button Click!')">456</b-button>I am popover
-            <b>component</b> content! <b-form-input v-model="popoverInput" type="text" />Name:
-            <strong>{{ popoverInput }}</strong>
+          <template #target>
+            <b-button id="popover-target-1">Hover Me</b-button>
           </template>
+          <b-button @click="consoleLog('Button Click!')">456</b-button>I am popover
+          <b>component</b> content! <b-form-input v-model="popoverInput" type="text" />Name:
+          <strong>{{ popoverInput }}</strong>
         </b-popover>
       </b-col>
       <b-col>
@@ -103,17 +105,17 @@
           :reference="() => popoverContainerRef"
           placement="right"
         >
-          <span>Not the real trigger or reference</span>
           <template #title>
             Popover
             <em>Title</em>
             - {{ popoverInput }}
           </template>
-          <template #content>
-            <b-button @click="consoleLog('Button Click!')">456</b-button>I am popover
-            <b>component</b> content! <b-form-input v-model="popoverInput" type="text" />Name:
-            <strong>{{ popoverInput }}</strong>
+          <template #target>
+            <span>Not the real trigger or reference</span>
           </template>
+          <b-button @click="consoleLog('Button Click!')">456</b-button>I am popover
+          <b>component</b> content! <b-form-input v-model="popoverInput" type="text" />Name:
+          <strong>{{ popoverInput }}</strong>
         </b-popover>
       </b-col>
     </b-row>
@@ -130,12 +132,10 @@
           <template #title>
             <h3>Popover title</h3>
           </template>
-          <template #content>
-            <p>
-              Position is calculated to parent relative element. (Try changing the textarea size)
-            </p>
-          </template>
-          <template #default="{toggle, showState}">
+
+          <p>Position is calculated to parent relative element. (Try changing the textarea size)</p>
+
+          <template #target="{toggle, showState}">
             <b-button @click="toggle">Click to toggle popover</b-button>
             <div>
               {{ showState ? 'Visible' : 'hidden' }}
@@ -157,21 +157,32 @@
             Popover
             <em>Title</em>
           </template>
-          <template #content>
-            <b-button @click="consoleLog('Button Click!')">456</b-button>I am popover
-            <b>component</b> content! <b-form-input v-model="popoverInput" type="text" />Name:
-            <strong>{{ popoverInput }}</strong>
+          <template #target>
+            <b-button>hover / focus</b-button>
           </template>
-          <b-button>hover / focus</b-button>
+          <b-button @click="consoleLog('Button Click!')">456</b-button>I am popover
+          <b>component</b> content! <b-form-input v-model="popoverInput" type="text" />Name:
+          <strong>{{ popoverInput }}</strong>
         </b-popover>
       </b-col>
       <b-col>
         <b-popover realtime :model-value="true" click placement="bottom">
           <template #title> Title </template>
-          <template #content>
-            Burn cpu cycles to be more accurate. Try changing the size of the textarea above.
+          <template #target>
+            <span class="border rounded m-3 p-2">sync position with RequestAnimationFrame</span>
           </template>
-          <span class="border rounded m-3 p-2">sync position with RequestAnimationFrame</span>
+          Burn cpu cycles to be more accurate. Try changing the size of the textarea above.
+        </b-popover>
+      </b-col>
+    </b-row>
+    <b-row>
+      <b-col>
+        <b-popover click placement="bottom" container="body">
+          <template #title> Title </template>
+          <template #target>
+            <span class="border rounded m-3 p-2">move to body.</span>
+          </template>
+          in body. {{ textValue }}
         </b-popover>
       </b-col>
     </b-row>

--- a/apps/playground/src/main.ts
+++ b/apps/playground/src/main.ts
@@ -3,7 +3,7 @@ import App from './App.vue'
 import router from './router'
 import {BootstrapVueNext, BToastPlugin} from 'bootstrap-vue-next'
 
-import 'bootstrap/dist/css/bootstrap.css'
+import 'bootstrap-styles/css/bootstrap.css'
 import 'bootstrap-vue-next/dist/bootstrap-vue-next.css'
 
 createApp(App).use(router).use(BootstrapVueNext).use(BToastPlugin).mount('#app')

--- a/apps/playground/src/router/index.ts
+++ b/apps/playground/src/router/index.ts
@@ -5,10 +5,10 @@ import HomePage from '../Views/HomePage.vue'
 export default createRouter({
   history: createWebHistory(),
   routes: [
-    {path: '/', name: 'Home', component: HomePage},
+    {path: '/', name: 'index', component: HomePage},
     {
       path: '/about',
-      name: 'About',
+      name: 'about',
       component: {
         name: 'About',
         render() {

--- a/packages/bootstrap-vue-next/package.json
+++ b/packages/bootstrap-vue-next/package.json
@@ -38,17 +38,15 @@
     "test:coverage": "vitest --coverage"
   },
   "peerDependencies": {
-    "bootstrap": "^5.2.3",
     "vue": "^3.2.45"
   },
   "dependencies": {
     "@floating-ui/vue": "^0.2.1",
-    "@nuxt/kit": "3.0.0",
+    "@nuxt/kit": "3.3.1",
     "@vueuse/core": "^9.11.1"
   },
   "devDependencies": {
     "@popperjs/core": "2.11.6",
-    "@types/bootstrap": "^5.2.6",
     "@vitejs/plugin-vue": "^3.2.0",
     "@vitest/coverage-c8": "^0.25.3",
     "@vue/compiler-dom": "^3.2.45",

--- a/packages/bootstrap-vue-next/src/components/BAccordion/BAccordionItem.vue
+++ b/packages/bootstrap-vue-next/src/components/BAccordion/BAccordionItem.vue
@@ -1,26 +1,27 @@
 <template>
   <div class="accordion-item">
-    <component :is="headerTag" :id="`${computedId}heading`" class="accordion-header">
-      <button
-        v-b-toggle:[computedId]
-        class="accordion-button"
-        :class="{collapsed: !visibleBoolean}"
-        type="button"
-        :aria-expanded="visibleBoolean ? 'true' : 'false'"
-        :aria-controls="computedId"
-      >
-        <slot name="title">
-          {{ title }}
-        </slot>
-      </button>
-    </component>
     <b-collapse
       :id="computedId"
+      v-model="open"
       class="accordion-collapse"
       :visible="visible"
       :accordion="parentData ?? undefined"
       :aria-labelledby="`heading${computedId}`"
     >
+      <template #header="{visible: toggleVisible, toggle}">
+        <component :is="headerTag" :id="`heading${computedId}`" class="accordion-header">
+          <button
+            class="accordion-button"
+            :class="{collapsed: !toggleVisible}"
+            type="button"
+            :aria-expanded="toggleVisible ? 'true' : 'false'"
+            :aria-controls="computedId"
+            @click="toggle"
+          >
+            <slot name="title"> {{ title }} </slot>
+          </button>
+        </component>
+      </template>
       <div class="accordion-body">
         <slot />
       </div>
@@ -29,9 +30,9 @@
 </template>
 
 <script setup lang="ts">
-import {inject, toRef} from 'vue'
+import {inject, onMounted, toRef, watchEffect} from 'vue'
+import {useVModel} from '@vueuse/core'
 import BCollapse from '../BCollapse.vue'
-import {BToggle as vBToggle} from '../../directives'
 import {accordionInjectionKey} from '../../utils'
 import {useBooleanish, useId} from '../../composables'
 import type {Booleanish} from '../../types'
@@ -40,18 +41,29 @@ import type {Booleanish} from '../../types'
 interface BAccordionItemProps {
   id?: string
   title?: string
+  modelValue?: boolean
   visible?: Booleanish
   headerTag?: string
 }
 
 const props = withDefaults(defineProps<BAccordionItemProps>(), {
-  visible: false,
   headerTag: 'h2',
 })
+
+const emit = defineEmits<(e: 'update:modelValue', value: boolean) => void>()
+const open = useVModel(props, 'modelValue', emit, {passive: true})
+
+const visibleBoolean = useBooleanish(toRef(props, 'visible'))
+
+onMounted(() => {
+  if (visibleBoolean.value) {
+    open.value = true
+  }
+})
+
+watchEffect(() => (open.value = visibleBoolean.value))
 
 const parentData = inject(accordionInjectionKey, null)
 
 const computedId = useId(toRef(props, 'id'), 'accordion_item')
-
-const visibleBoolean = useBooleanish(toRef(props, 'visible'))
 </script>

--- a/packages/bootstrap-vue-next/src/components/BAccordion/accordion-item.spec.ts
+++ b/packages/bootstrap-vue-next/src/components/BAccordion/accordion-item.spec.ts
@@ -24,7 +24,7 @@ describe('accordion-item', () => {
 
   it('b-collapse contains static class accordion-collapse', () => {
     const wrapper = mount(BAccordionItem)
-    const $bcollapse = wrapper.findComponent(BCollapse)
+    const [, $bcollapse] = wrapper.findComponent(BCollapse).findAll('*')
     expect($bcollapse.classes()).toContain('accordion-collapse')
   })
 
@@ -53,7 +53,7 @@ describe('accordion-item', () => {
 
   it('b-collapse has id attr has default id', () => {
     const wrapper = mount(BAccordionItem)
-    const $bcollapse = wrapper.findComponent(BCollapse)
+    const [$bcollapse] = wrapper.findComponent(BCollapse).findAll('*')
     expect($bcollapse.attributes('id')).toBeDefined()
   })
 
@@ -61,7 +61,7 @@ describe('accordion-item', () => {
     const wrapper = mount(BAccordionItem, {
       props: {id: 'spam&eggs'},
     })
-    const $bcollapse = wrapper.findComponent(BCollapse)
+    const [, $bcollapse] = wrapper.findComponent(BCollapse).findAll('*')
     expect($bcollapse.attributes('id')).toBe('spam&eggs')
   })
 
@@ -79,7 +79,7 @@ describe('accordion-item', () => {
     const wrapper = mount(BAccordionItem, {
       props: {id: 'foobar'},
     })
-    const $bcollapse = wrapper.findComponent(BCollapse)
+    const [, $bcollapse] = wrapper.findComponent(BCollapse).findAll('*')
     expect($bcollapse.attributes('aria-labelledby')).toBe('headingfoobar')
   })
 
@@ -114,7 +114,7 @@ describe('accordion-item', () => {
       props: {id: 'foobar'},
     })
     const $h2 = wrapper.get('h2')
-    expect($h2.attributes('id')).toBe('foobarheading')
+    expect($h2.attributes('id')).toBe('headingfoobar')
   })
 
   it('h2 child has button child', () => {

--- a/packages/bootstrap-vue-next/src/components/BCollapse.vue
+++ b/packages/bootstrap-vue-next/src/components/BCollapse.vue
@@ -1,24 +1,25 @@
 <template>
+  <slot name="header" v-bind="{visible: modelValueBoolean, toggle, open, close, id: computedId}" />
   <component
     :is="tag"
     :id="computedId"
     ref="element"
     class="collapse"
     :class="computedClasses"
-    :data-bs-parent="accordion || null"
     :is-nav="isNavBoolean"
+    v-bind="$attrs"
   >
-    <slot :visible="modelValueBoolean" :close="close" />
+    <slot v-bind="{visible: modelValueBoolean, toggle, open, close}" />
   </component>
+  <slot name="footer" v-bind="{visible: modelValueBoolean, toggle, open, close, id: computedId}" />
 </template>
 
 <script setup lang="ts">
-// import type {BCollapseEmits, BCollapseProps} from '../types/components'
-import {computed, onMounted, ref, toRef, watch} from 'vue'
-import {Collapse} from 'bootstrap'
+import {computed, nextTick, onMounted, ref, toRef, watch, watchEffect} from 'vue'
 import {useBooleanish, useId} from '../composables'
 import {useEventListener, useVModel} from '@vueuse/core'
 import type {Booleanish} from '../types'
+import {BvTriggerableEvent} from '../utils'
 
 interface BCollapseProps {
   accordion?: string
@@ -27,6 +28,7 @@ interface BCollapseProps {
   modelValue?: Booleanish
   tag?: string
   toggle?: Booleanish
+  horizontal?: Booleanish
   visible?: Booleanish
   isNav?: Booleanish
 }
@@ -35,69 +37,166 @@ const props = withDefaults(defineProps<BCollapseProps>(), {
   modelValue: false,
   tag: 'div',
   toggle: false,
+  horizontal: false,
   visible: false,
   isNav: false,
 })
 
 interface BCollapseEmits {
+  (e: 'show', value: BvTriggerableEvent): void
+  (e: 'shown', value: BvTriggerableEvent): void
+  (e: 'hide', value: BvTriggerableEvent): void
+  (e: 'hidden', value: BvTriggerableEvent): void
+  (e: 'hide-prevented'): void
+  (e: 'show-prevented'): void
   (e: 'update:modelValue', value: boolean): void
-  (e: 'show'): void
-  (e: 'shown'): void
-  (e: 'hide'): void
-  (e: 'hidden'): void
 }
+
+const buildTriggerableEvent = (
+  type: string,
+  opts: Partial<BvTriggerableEvent> = {}
+): BvTriggerableEvent =>
+  new BvTriggerableEvent(type, {
+    cancelable: false,
+    target: element.value || null,
+    relatedTarget: null,
+    trigger: null,
+    ...opts,
+    componentId: computedId.value,
+  })
 
 const emit = defineEmits<BCollapseEmits>()
 
-const modelValue = useVModel(props, 'modelValue', emit)
+const modelValue = useVModel(props, 'modelValue', emit, {passive: true})
 
 const modelValueBoolean = useBooleanish(modelValue)
 const toggleBoolean = useBooleanish(toRef(props, 'toggle'))
-const visibleBoolean = useBooleanish(toRef(props, 'visible'))
+const horizontalBoolean = useBooleanish(toRef(props, 'horizontal'))
 const isNavBoolean = useBooleanish(toRef(props, 'isNav'))
+const visibleBoolean = useBooleanish(toRef(props, 'visible'))
 
 const computedId = useId(toRef(props, 'id'), 'collapse')
 
-const element = ref<HTMLElement | null>(null)
-const instance = ref<Collapse>()
+const element = ref<HTMLElement>(null as unknown as HTMLElement)
+const isCollapsing = ref(false)
+const show = ref(modelValueBoolean.value)
 
 const computedClasses = computed(() => ({
-  'show': modelValueBoolean.value,
+  'show': show.value,
   'navbar-collapse': isNavBoolean.value,
+  'collapsing': isCollapsing.value,
+  'closing': show.value && !modelValue.value,
+  'collapse-horizontal': horizontalBoolean.value,
 }))
 
 const close = () => (modelValue.value = false)
+const open = () => (modelValue.value = true)
+const toggle = () => (modelValue.value = !modelValue.value)
 
-watch(modelValueBoolean, (value) => {
-  value ? instance.value?.show() : instance.value?.hide()
+const reveal = () => {
+  show.value = true
+  isCollapsing.value = true
+  const event = buildTriggerableEvent('show', {cancelable: true})
+  emit('show', event)
+  if (event.defaultPrevented) {
+    emit('show-prevented')
+    return
+  }
+  nextTick(() => {
+    if (horizontalBoolean.value) {
+      element.value.style.width = `${element.value.scrollWidth}px`
+    } else {
+      element.value.style.height = `${element.value.scrollHeight}px`
+    }
+    setTimeout(() => {
+      isCollapsing.value = false
+      emit('shown', buildTriggerableEvent('shown'))
+      if (element.value === null) return
+      element.value.style.height = ''
+      element.value.style.width = ''
+    }, getTransitionDelay(element.value))
+  })
+}
+
+const hide = () => {
+  const event = buildTriggerableEvent('hide', {cancelable: true})
+  emit('hide', event)
+  if (event.defaultPrevented) {
+    emit('hide-prevented')
+    return
+  }
+  if (horizontalBoolean.value) {
+    element.value.style.width = `${element.value.scrollWidth}px`
+  } else {
+    element.value.style.height = `${element.value.scrollHeight}px`
+  }
+  // element.value.style.height = `${element.value.scrollHeight}px`
+  element.value.offsetHeight // force reflow
+  isCollapsing.value = true
+  nextTick(() => {
+    element.value.style.height = ``
+    element.value.style.width = ``
+    setTimeout(() => {
+      show.value = false
+      isCollapsing.value = false
+      emit('hidden', buildTriggerableEvent('hidden'))
+    }, getTransitionDelay(element.value))
+  })
+}
+
+watch(modelValue, (newValue, oldValue) => {
+  if (newValue === oldValue) return
+  if (element.value === null) return
+  if (newValue) {
+    if (show.value) return
+    reveal()
+  } else {
+    hide()
+  }
 })
 
-watch(visibleBoolean, (value) => {
-  modelValue.value = !!value
-  value ? instance.value?.show() : instance.value?.hide()
-})
-
-useEventListener(element, 'show.bs.collapse', () => {
-  emit('show')
-  modelValue.value = true
-})
-
-useEventListener(element, 'hide.bs.collapse', () => {
-  emit('hide')
-  modelValue.value = false
-})
-useEventListener(element, 'shown.bs.collapse', () => emit('shown'))
-useEventListener(element, 'hidden.bs.collapse', () => emit('hidden'))
+function getTransitionDelay(element: HTMLElement) {
+  const style = window.getComputedStyle(element)
+  // if multiple durations are defined, we take the first
+  const transitionDelay = style.transitionDelay.split(',')[0] || ''
+  const transitionDuration = style.transitionDuration.split(',')[0] || ''
+  const transitionDelayMs = Number(transitionDelay.slice(0, -1)) * 1000
+  const transitionDurationMs = Number(transitionDuration.slice(0, -1)) * 1000
+  return transitionDelayMs + transitionDurationMs
+}
 
 onMounted(() => {
   if (element.value === null) return
-  instance.value = new Collapse(element.value, {
-    parent: props.accordion ? `#${props.accordion}` : undefined,
-    toggle: toggleBoolean.value,
-  })
-  if (visibleBoolean.value || modelValueBoolean.value) {
-    modelValue.value = true
-    instance.value?.show()
+  if (!modelValue.value && toggleBoolean.value) {
+    nextTick(() => {
+      modelValue.value = true
+    })
   }
 })
+
+if (visibleBoolean.value) {
+  modelValue.value = true
+  show.value = true
+}
+
+watchEffect(() => {
+  visibleBoolean.value ? open() : close()
+})
+
+useEventListener(element, 'bv-toggle', () => {
+  modelValue.value = !modelValue.value
+})
+
+defineExpose({
+  close,
+  open,
+  toggle,
+  visible: show.value,
+})
+</script>
+
+<script lang="ts">
+export default {
+  inheritAttrs: false,
+}
 </script>

--- a/packages/bootstrap-vue-next/src/components/BModal.vue
+++ b/packages/bootstrap-vue-next/src/components/BModal.vue
@@ -97,7 +97,7 @@
 // import type {BModalEmits, BModalProps} from '../types/components'
 import {computed, onMounted, ref, toRef, useSlots} from 'vue'
 import {useBooleanish, useId} from '../composables'
-import {useFocus, useVModel} from '@vueuse/core'
+import {useEventListener, useFocus, useVModel} from '@vueuse/core'
 import type {Booleanish, ClassValue, ColorVariant, InputSize} from '../types'
 import {BvTriggerableEvent, isEmptySlot} from '../utils'
 import BButton from './BButton/BButton.vue'
@@ -386,6 +386,10 @@ onMounted(() => {
   if (modelValueBoolean.value === true) {
     isActive.value = true
   }
+})
+
+useEventListener(element, 'bv-toggle', () => {
+  modelValue.value ? hide() : show()
 })
 </script>
 

--- a/packages/bootstrap-vue-next/src/components/BOffcanvas/BOffcanvas.vue
+++ b/packages/bootstrap-vue-next/src/components/BOffcanvas/BOffcanvas.vue
@@ -63,7 +63,7 @@
 
 <script setup lang="ts">
 import {computed, onMounted, ref, toRef, useSlots, watch} from 'vue'
-import {useVModel} from '@vueuse/core'
+import {useEventListener, useVModel} from '@vueuse/core'
 import {useBooleanish, useId} from '../../composables'
 import type {Booleanish, ColorVariant} from '../../types'
 import {BvTriggerableEvent, isEmptySlot} from '../../utils'
@@ -239,6 +239,9 @@ watch(
   },
   {flush: 'post'}
 )
+useEventListener(element, 'bv-toggle', () => {
+  modelValue.value ? hide() : show()
+})
 </script>
 
 <script lang="ts">

--- a/packages/bootstrap-vue-next/src/components/BToast/plugin.ts
+++ b/packages/bootstrap-vue-next/src/components/BToast/plugin.ts
@@ -189,10 +189,8 @@ export class ToastController {
 }
 
 // default global inject key to fetch the controller
-const injectkey = Symbol()
-const fetchKey = Symbol()
-
-const rootkey = 'root' // TODO: I guess this variable is not used in any place...
+const injectkey = Symbol('toast')
+const fetchKey = Symbol('toastFetch')
 
 const defaults = {
   container: undefined,

--- a/packages/bootstrap-vue-next/src/components/collapse.spec.ts
+++ b/packages/bootstrap-vue-next/src/components/collapse.spec.ts
@@ -7,58 +7,60 @@ describe('collapse', () => {
 
   it('has static class collapse', () => {
     const wrapper = mount(BCollapse)
-    expect(wrapper.classes()).toContain('collapse')
+    expect(wrapper.findAll('*')[0].classes()).toContain('collapse')
+    // expect(wrapper.classes()).toContain('collapse')
   })
 
   it('has default tag div', () => {
     const wrapper = mount(BCollapse)
-    expect(wrapper.element.tagName).toBe('DIV')
+    expect(wrapper.findAll('*')[0].element.tagName).toBe('DIV')
   })
 
   it('is tag when prop tag', () => {
     const wrapper = mount(BCollapse, {
       props: {tag: 'span'},
     })
-    expect(wrapper.element.tagName).toBe('SPAN')
+    expect(wrapper.findAll('*')[0].element.tagName).toBe('SPAN')
   })
 
   it('has default id', () => {
     const wrapper = mount(BCollapse)
-    expect(wrapper.attributes('id')).toBeDefined()
+    expect(wrapper.findAll('*')[0].attributes('id')).toBeDefined()
   })
 
   it('has id as prop id', () => {
     const wrapper = mount(BCollapse, {
       props: {id: 'foobar'},
     })
-    expect(wrapper.attributes('id')).toBe('foobar')
-  })
-
-  it('has data-bs-parent when prop accordion', () => {
-    const wrapper = mount(BCollapse, {
-      props: {accordion: 'abc'},
-    })
-    expect(wrapper.attributes('data-bs-parent')).toBe('abc')
-  })
-
-  it('has data-bs-parent null when accordion undefined', () => {
-    const wrapper = mount(BCollapse)
-    expect(wrapper.attributes('data-bs-parent')).toBeUndefined()
+    expect(wrapper.findAll('*')[0].attributes?.('id')).toBe('foobar')
   })
 
   it('has attribute is-nav when prop is nav', async () => {
     const wrapper = mount(BCollapse, {
       props: {isNav: true},
     })
-    expect(wrapper.attributes('is-nav')).toBe('true')
+    expect(wrapper.findAll('*')[0].attributes('is-nav')).toBe('true')
     await wrapper.setProps({isNav: false})
-    expect(wrapper.attributes('is-nav')).toBe('false')
+    expect(wrapper.findAll('*')[0].attributes('is-nav')).toBe('false')
   })
 
   it('renders default slot', () => {
     const wrapper = mount(BCollapse, {
       slots: {default: 'foobar'},
     })
-    expect(wrapper.text()).toBe('foobar')
+    expect(wrapper.findAll('*')[0].text()).toBe('foobar')
+  })
+
+  it('renders all slot', () => {
+    const wrapper = mount(BCollapse, {
+      slots: {
+        default: 'default',
+        header: '<div>header</div>',
+        footer: '<div>footer</div>',
+      },
+    })
+    expect(wrapper.findAll('*')[0].text()).toBe('header')
+    expect(wrapper.findAll('*')[1].text()).toBe('default')
+    expect(wrapper.findAll('*')[2].text()).toBe('footer')
   })
 })

--- a/packages/bootstrap-vue-next/src/directives/BModal.ts
+++ b/packages/bootstrap-vue-next/src/directives/BModal.ts
@@ -1,19 +1,2 @@
-import type {Directive, DirectiveBinding} from 'vue'
-
-// TODO data-bs-toggle/target are not valid anymore.
-/**
- *
- * This is not marked as external, but in the future I think it may be
- */
-export default {
-  mounted(el, binding: DirectiveBinding): void {
-    let target: string = binding.value
-
-    if (Object.keys(binding.modifiers).length > 0) {
-      ;[target] = Object.keys(binding.modifiers)
-    }
-
-    el.setAttribute('data-bs-toggle', 'modal')
-    el.setAttribute('data-bs-target', `#${target}`)
-  },
-} as Directive<HTMLElement>
+import BToggle from './BToggle'
+export default BToggle

--- a/packages/bootstrap-vue-next/src/directives/BPopover.ts
+++ b/packages/bootstrap-vue-next/src/directives/BPopover.ts
@@ -9,7 +9,7 @@ import {
 
 export default {
   mounted(el, binding) {
-    const text = resolveContent(binding.value)
+    const text = resolveContent(binding.value, el)
 
     el.$__state = ref({
       ...resolveDirectiveProps(binding, el),
@@ -18,7 +18,7 @@ export default {
     bind(el, binding)
   },
   updated(el, binding) {
-    const text = resolveContent(binding.value)
+    const text = resolveContent(binding.value, el)
 
     if (!el.$__state) return
     el.$__state.value = {

--- a/packages/bootstrap-vue-next/src/directives/BToggle.ts
+++ b/packages/bootstrap-vue-next/src/directives/BToggle.ts
@@ -63,13 +63,23 @@ const checkVisibility = (binding: DirectiveBinding<string>, el: HTMLElement) => 
   el.setAttribute('aria-expanded', visible ? 'true' : 'false')
 }
 
+interface WithToggle extends HTMLElement {
+  __toggle: () => void
+}
+
 /**
  * @external
  */
 export default {
-  mounted(el, binding: DirectiveBinding<string>): void {
-    el.addEventListener('click', () => toggle(binding, el))
+  mounted(el: WithToggle, binding: DirectiveBinding<string>): void {
+    el.__toggle = () => toggle(binding, el)
+    el.addEventListener('click', el.__toggle)
     checkVisibility(binding, el)
     el.setAttribute('aria-controls', getTargets(binding, el).join(' '))
   },
-} as Directive<HTMLElement>
+  unmounted(el: WithToggle): void {
+    el.removeEventListener('click', el.__toggle)
+    el.removeAttribute('aria-controls')
+    el.removeAttribute('aria-expanded')
+  },
+} as Directive<WithToggle>

--- a/packages/bootstrap-vue-next/src/directives/BTooltip.ts
+++ b/packages/bootstrap-vue-next/src/directives/BTooltip.ts
@@ -9,7 +9,7 @@ import {
 
 export default {
   mounted(el, binding) {
-    const text = resolveContent(binding.value)
+    const text = resolveContent(binding.value, el)
 
     el.$__state = ref({
       ...resolveDirectiveProps(binding, el),
@@ -19,7 +19,7 @@ export default {
     bind(el, binding)
   },
   updated(el, binding) {
-    const text = resolveContent(binding.value)
+    const text = resolveContent(binding.value, el)
     if (!el.$__state) return
     el.$__state.value = {
       ...resolveDirectiveProps(binding, el),

--- a/packages/bootstrap-vue-next/vite.config.ts
+++ b/packages/bootstrap-vue-next/vite.config.ts
@@ -18,16 +18,14 @@ export default defineConfig({
     rollupOptions: {
       // make sure to externalize deps that shouldn't be bundled
       // into your library
-      external: ['bootstrap', 'bootstrap/js/dist/collapse', 'vue'],
+      external: ['vue'],
       output: {
         exports: 'named',
         assetFileNames: `bootstrap-vue-next.[ext]`, //without this, it generates build/styles.css
         // Provide global variables to use in the UMD build
         // for externalized deps
         globals: {
-          'vue': 'Vue',
-          'bootstrap': 'Bootstrap',
-          'bootstrap/js/dist/collapse': 'Collapse',
+          vue: 'Vue',
         },
       },
     },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,7 +14,7 @@ importers:
       husky: 8.0.3
       lint-staged: 13.1.0
       release-please: 15.5.0
-      turbo: 1.8.2
+      turbo: 1.8.3
 
   apps/docs:
     specifiers:
@@ -44,9 +44,8 @@ importers:
 
   apps/playground:
     specifiers:
-      '@popperjs/core': 2.11.6
       '@vitejs/plugin-vue': 3.2.0
-      bootstrap: 5.2.3
+      bootstrap-styles: 5.2.3
       bootstrap-vue-next: workspace:*
       rollup-plugin-visualizer: 5.8.3
       tsconfig: workspace:*
@@ -56,13 +55,12 @@ importers:
       vue-router: 4.1.6
       vue-tsc: 1.0.13
     dependencies:
-      '@popperjs/core': 2.11.6
-      bootstrap: 5.2.3_@popperjs+core@2.11.6
       bootstrap-vue-next: link:../../packages/bootstrap-vue-next
       vue: 3.2.45
       vue-router: 4.1.6_vue@3.2.45
     devDependencies:
       '@vitejs/plugin-vue': 3.2.0_vite@3.2.4+vue@3.2.45
+      bootstrap-styles: 5.2.3
       rollup-plugin-visualizer: 5.8.3
       tsconfig: link:../../packages/tsconfig
       typescript: 4.9.3
@@ -72,9 +70,8 @@ importers:
   packages/bootstrap-vue-next:
     specifiers:
       '@floating-ui/vue': ^0.2.1
-      '@nuxt/kit': 3.0.0
+      '@nuxt/kit': 3.3.1
       '@popperjs/core': 2.11.6
-      '@types/bootstrap': ^5.2.6
       '@vitejs/plugin-vue': ^3.2.0
       '@vitest/coverage-c8': ^0.25.3
       '@vue/compiler-dom': ^3.2.45
@@ -100,11 +97,10 @@ importers:
       vue-tsc: ^1.0.13
     dependencies:
       '@floating-ui/vue': 0.2.1_vue@3.2.45
-      '@nuxt/kit': 3.0.0_rollup@3.12.0
+      '@nuxt/kit': 3.3.1_rollup@3.12.0
       '@vueuse/core': 9.11.1_vue@3.2.45
     devDependencies:
       '@popperjs/core': 2.11.6
-      '@types/bootstrap': 5.2.6
       '@vitejs/plugin-vue': 3.2.0_vite@3.2.5+vue@3.2.45
       '@vitest/coverage-c8': 0.25.8_vqsubjtly7ows4nunb2dz4jyqi
       '@vue/compiler-dom': 3.2.45
@@ -149,6 +145,9 @@ importers:
       eslint-plugin-vue: 9.9.0_eslint@8.32.0
       prettier: 2.8.3
       typescript: 4.9.4
+
+  packages/nuxt:
+    specifiers: {}
 
   packages/shared:
     specifiers: {}
@@ -710,48 +709,49 @@ packages:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.15.0
 
-  /@nuxt/kit/3.0.0_rollup@3.12.0:
-    resolution: {integrity: sha512-7ZsOLt5s9a0ZleAIzmoD70JwkZf5ti6bDdxl6f8ew7Huxz+ni/oRfTPTX9TrORXsgW5CvDt6Q9M7IJNPkAN/Iw==}
-    engines: {node: ^14.16.0 || ^16.10.0 || ^17.0.0 || ^18.0.0 || ^19.0.0}
+  /@nuxt/kit/3.3.1_rollup@3.12.0:
+    resolution: {integrity: sha512-zb7/2FUIB1g7nl6K6qozUzfG5uu4yrs9TQjZvpASnPBZ/x1EuJX5k3AA71hMMIVBEX9Adxvh9AuhDEHE5W26Zg==}
+    engines: {node: ^14.18.0 || ^16.10.0 || ^17.0.0 || ^18.0.0 || ^19.0.0}
     dependencies:
-      '@nuxt/schema': 3.0.0_rollup@3.12.0
-      c12: 1.1.0
+      '@nuxt/schema': 3.3.1_rollup@3.12.0
+      c12: 1.2.0
       consola: 2.15.3
       defu: 6.1.2
       globby: 13.1.3
       hash-sum: 2.0.0
       ignore: 5.2.4
-      jiti: 1.16.2
+      jiti: 1.18.2
       knitwork: 1.0.0
       lodash.template: 4.5.0
-      mlly: 1.1.0
+      mlly: 1.2.0
       pathe: 1.1.0
-      pkg-types: 1.0.1
+      pkg-types: 1.0.2
       scule: 1.0.0
       semver: 7.3.8
-      unctx: 2.1.1
-      unimport: 1.3.0_rollup@3.12.0
+      unctx: 2.1.2
+      unimport: 3.0.3_rollup@3.12.0
       untyped: 1.2.2
     transitivePeerDependencies:
       - rollup
       - supports-color
     dev: false
 
-  /@nuxt/schema/3.0.0_rollup@3.12.0:
-    resolution: {integrity: sha512-5fwsidhs5NjFzR8sIzHMXO0WFGkI3tCH3ViANn2W4N5qCwoYZ0n1sZBkQ9Esn1VoEed6RsIlTpWrPZPVtqNkGQ==}
-    engines: {node: ^14.16.0 || ^16.10.0 || ^17.0.0 || ^18.0.0 || ^19.0.0}
+  /@nuxt/schema/3.3.1_rollup@3.12.0:
+    resolution: {integrity: sha512-E8HWzU43rXzqwDTmWduTLHY4xIwRSAUt1LbpuE9IjZ4uJZq5Mbaj4nfhANNsTQGw2c+O+rL81yzAP3i61LEJDw==}
+    engines: {node: ^14.18.0 || ^16.10.0 || ^17.0.0 || ^18.0.0 || ^19.0.0}
     dependencies:
-      c12: 1.1.0
+      c12: 1.2.0
       create-require: 1.1.1
       defu: 6.1.2
-      jiti: 1.16.2
+      hookable: 5.5.1
+      jiti: 1.18.2
       pathe: 1.1.0
-      pkg-types: 1.0.1
+      pkg-types: 1.0.2
       postcss-import-resolver: 2.0.0
       scule: 1.0.0
-      std-env: 3.3.1
-      ufo: 1.0.1
-      unimport: 1.3.0_rollup@3.12.0
+      std-env: 3.3.2
+      ufo: 1.1.1
+      unimport: 3.0.3_rollup@3.12.0
       untyped: 1.2.2
     transitivePeerDependencies:
       - rollup
@@ -876,6 +876,7 @@ packages:
 
   /@popperjs/core/2.11.6:
     resolution: {integrity: sha512-50/17A98tWUfQ176raKiOGXuYpLyyVMkxxG6oylzL3BPOlA6ADGdK7EYunSa4I064xerltq9TGXs8HmOk5E+vw==}
+    dev: true
 
   /@rollup/pluginutils/5.0.2_rollup@3.12.0:
     resolution: {integrity: sha512-pTd9rIsP92h+B6wWwFbW8RkZv4hiR/xKsqre4SIuAOaOEQRxi0lqLke9k2/7WegC85GgUs9pjmOjCUi3In4vwA==}
@@ -936,12 +937,6 @@ packages:
 
   /@types/argparse/1.0.38:
     resolution: {integrity: sha512-ebDJ9b0e702Yr7pWgB0jzm+CX4Srzz8RcXtLJDJB+BSccqMa36uyH/zUsSYao5+BD1ytv3k3rPYCq4mAE1hsXA==}
-    dev: true
-
-  /@types/bootstrap/5.2.6:
-    resolution: {integrity: sha512-BlAc3YATdasbHoxMoBWODrSF6qwQO/E9X8wVxCCSa6rWjnaZfpkr2N6pUMCY6jj2+wf0muUtLySbvU9etX6YqA==}
-    dependencies:
-      '@popperjs/core': 2.11.6
     dev: true
 
   /@types/chai-subset/1.3.3:
@@ -1958,12 +1953,17 @@ packages:
     resolution: {integrity: sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==}
     dev: true
 
+  /bootstrap-styles/5.2.3:
+    resolution: {integrity: sha512-LOoxcEoIdtsEedb5ogueIfXdOe3EIjzonA2ssp0aMKIVd8Cx1wsrVgvO4Z0dR7f7SaLXrYqHQT4k1EFO93+pHQ==}
+    dev: true
+
   /bootstrap/5.2.3_@popperjs+core@2.11.6:
     resolution: {integrity: sha512-cEKPM+fwb3cT8NzQZYEu4HilJ3anCrWqh3CHAok1p9jXqMPsPTBhU25fBckEJHJ/p+tTxTFTsFQGM+gaHpi3QQ==}
     peerDependencies:
       '@popperjs/core': ^2.11.6
     dependencies:
       '@popperjs/core': 2.11.6
+    dev: true
 
   /brace-expansion/1.1.11:
     resolution: {integrity: sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==}
@@ -2005,16 +2005,16 @@ packages:
     resolution: {integrity: sha512-uYBjakWipfaO/bXI7E8rq6kpwHRZK5cNYrUv2OzZSI/FvmdMyXJ2tG9dKcjEC5YHmHpUAwsargWIZNWdxb/bnQ==}
     dev: true
 
-  /c12/1.1.0:
-    resolution: {integrity: sha512-9KRFWEng+TH8sGST4NNdiKzZGw1Z1CHnPGAmNqAyVP7suluROmBjD8hsiR34f94DdlrvtGvvmiGDsoFXlCBWIw==}
+  /c12/1.2.0:
+    resolution: {integrity: sha512-CMznkE0LpNEuD8ILp5QvsQVP+YvcpJnrI/zFeFnosU2PyDtx1wT7tXfZ8S3Tl3l9MTTXbKeuhDYKwgvnAPOx3w==}
     dependencies:
       defu: 6.1.2
       dotenv: 16.0.3
-      giget: 1.0.0
-      jiti: 1.16.2
-      mlly: 1.1.0
+      giget: 1.1.2
+      jiti: 1.18.2
+      mlly: 1.2.0
       pathe: 1.1.0
-      pkg-types: 1.0.1
+      pkg-types: 1.0.2
       rc9: 2.0.1
     transitivePeerDependencies:
       - supports-color
@@ -3466,15 +3466,15 @@ packages:
     engines: {node: '>=10'}
     dev: true
 
-  /giget/1.0.0:
-    resolution: {integrity: sha512-KWELZn3Nxq5+0So485poHrFriK9Bn3V/x9y+wgqrHkbmnGbjfLmZ685/SVA/ovW+ewoqW0gVI47pI4yW/VNobQ==}
+  /giget/1.1.2:
+    resolution: {integrity: sha512-HsLoS07HiQ5oqvObOI+Qb2tyZH4Gj5nYGfF9qQcZNrPw+uEFhdXtgJr01aO2pWadGHucajYDLxxbtQkm97ON2A==}
     hasBin: true
     dependencies:
       colorette: 2.0.19
       defu: 6.1.2
       https-proxy-agent: 5.0.1
       mri: 1.2.0
-      node-fetch-native: 1.0.1
+      node-fetch-native: 1.0.2
       pathe: 1.1.0
       tar: 6.1.13
     transitivePeerDependencies:
@@ -3626,6 +3626,10 @@ packages:
     resolution: {integrity: sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==}
     hasBin: true
     dev: true
+
+  /hookable/5.5.1:
+    resolution: {integrity: sha512-ac50aYjbtRMMZEtTG0qnVaBDA+1lqL9fHzDnxMQlVuO6LZWcBB7NXjIu9H9iImClewNdrit4RiEzi9QpRTgKrg==}
+    dev: false
 
   /hosted-git-info/2.8.9:
     resolution: {integrity: sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==}
@@ -3880,8 +3884,8 @@ packages:
       istanbul-lib-report: 3.0.0
     dev: true
 
-  /jiti/1.16.2:
-    resolution: {integrity: sha512-OKBOVWmU3FxDt/UH4zSwiKPuc1nihFZiOD722FuJlngvLz2glX1v2/TJIgoA4+mrpnXxHV6dSAoCvPcYQtoG5A==}
+  /jiti/1.18.2:
+    resolution: {integrity: sha512-QAdOptna2NYiSSpv0O/BwoHBSmz4YhpzJHyi+fnMRTXFjp7B8i/YG5Z8IfusxB1ufjcD2Sre1F3R+nX3fvy7gg==}
     hasBin: true
     dev: false
 
@@ -4216,15 +4220,15 @@ packages:
     dependencies:
       sourcemap-codec: 1.4.8
 
-  /magic-string/0.26.7:
-    resolution: {integrity: sha512-hX9XH3ziStPoPhJxLq1syWuZMxbDvGNbVchfrdCtanC7D13888bMFow61x8axrx+GfHLtVeAx2kxL7tTGRl+Ow==}
-    engines: {node: '>=12'}
-    dependencies:
-      sourcemap-codec: 1.4.8
-    dev: false
-
   /magic-string/0.27.0:
     resolution: {integrity: sha512-8UnnX2PeRAPZuN12svgR9j7M1uWMovg/CEnIwIG0LFkXSJJe4PdfUGiTGl8V9bsBHFUtfVINcSyYxd7q+kx9fA==}
+    engines: {node: '>=12'}
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.4.14
+    dev: false
+
+  /magic-string/0.30.0:
+    resolution: {integrity: sha512-LA+31JYDJLs82r2ScLrlz1GjSgu66ZV518eyWT+S8VhyQn/JL0u9MeBOvQMGYiPk1DBiSN9DDMOcXvigJZaViQ==}
     engines: {node: '>=12'}
     dependencies:
       '@jridgewell/sourcemap-codec': 1.4.14
@@ -4412,13 +4416,13 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
-  /mlly/1.1.0:
-    resolution: {integrity: sha512-cwzBrBfwGC1gYJyfcy8TcZU1f+dbH/T+TuOhtYP2wLv/Fb51/uV7HJQfBPtEupZ2ORLRU1EKFS/QfS3eo9+kBQ==}
+  /mlly/1.2.0:
+    resolution: {integrity: sha512-+c7A3CV0KGdKcylsI6khWyts/CYrGTrRVo4R/I7u/cUsy0Conxa6LUhiEzVKIw14lc2L5aiO4+SeVe4TeGRKww==}
     dependencies:
       acorn: 8.8.2
       pathe: 1.1.0
-      pkg-types: 1.0.1
-      ufo: 1.0.1
+      pkg-types: 1.0.2
+      ufo: 1.1.1
     dev: false
 
   /modify-values/1.0.1:
@@ -4455,8 +4459,8 @@ packages:
     resolution: {integrity: sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==}
     dev: true
 
-  /node-fetch-native/1.0.1:
-    resolution: {integrity: sha512-VzW+TAk2wE4X9maiKMlT+GsPU4OMmR1U9CrHSmd3DFLn2IcZ9VJ6M6BBugGfYUnPCLSYxXdZy17M0BEJyhUTwg==}
+  /node-fetch-native/1.0.2:
+    resolution: {integrity: sha512-KIkvH1jl6b3O7es/0ShyCgWLcfXxlBrLBbP3rOr23WArC66IMcU4DeZEeYEOwnopYhawLTn7/y+YtmASe8DFVQ==}
     dev: false
 
   /node-fetch/2.6.8:
@@ -4781,11 +4785,11 @@ packages:
     engines: {node: '>=6'}
     dev: true
 
-  /pkg-types/1.0.1:
-    resolution: {integrity: sha512-jHv9HB+Ho7dj6ItwppRDDl0iZRYBD0jsakHXtFgoLr+cHSF6xC+QL54sJmWxyGxOLYSHm0afhXhXcQDQqH9z8g==}
+  /pkg-types/1.0.2:
+    resolution: {integrity: sha512-hM58GKXOcj8WTqUXnsQyJYXdeAPbythQgEF3nTcEo+nkD49chjQ9IKm/QJy9xf6JakXptz86h7ecP2024rrLaQ==}
     dependencies:
       jsonc-parser: 3.2.0
-      mlly: 1.1.0
+      mlly: 1.2.0
       pathe: 1.1.0
     dev: false
 
@@ -5305,8 +5309,8 @@ packages:
       escodegen: 1.14.3
     dev: true
 
-  /std-env/3.3.1:
-    resolution: {integrity: sha512-3H20QlwQsSm2OvAxWIYhs+j01MzzqwMwGiiO1NQaJYZgJZFPuAbf95/DiKRBSTYIJ2FeGUc+B/6mPGcWP9dO3Q==}
+  /std-env/3.3.2:
+    resolution: {integrity: sha512-uUZI65yrV2Qva5gqE0+A7uVAvO40iPo6jGhs7s8keRfHCmtg+uB2X6EiLGCI9IgL1J17xGhvoOqSz79lzICPTA==}
     dev: false
 
   /string-argv/0.3.1:
@@ -5394,6 +5398,13 @@ packages:
     resolution: {integrity: sha512-5o4LsH1lzBzO9UFH63AJ2ad2/S2AVx6NtjOcaz+VTT2h1RiRvbipW72z8M/lxEhcPHDBQwpDrnTF7sXy/7OwCQ==}
     dependencies:
       acorn: 8.8.2
+    dev: true
+
+  /strip-literal/1.0.1:
+    resolution: {integrity: sha512-QZTsipNpa2Ppr6v1AmJHESqJ3Uz247MUS0OjrnnZjFAvEoWqxuyFuXn2xLgMtRnijJShAa1HL0gtJyUs7u7n3Q==}
+    dependencies:
+      acorn: 8.8.2
+    dev: false
 
   /strong-log-transformer/2.1.0:
     resolution: {integrity: sha512-B3Hgul+z0L9a236FAUC9iZsL+nVHgoCJnqCbN588DjYxvGXaXaaFbfmQ/JhvKjZwsOukuR72XbHv71Qkug0HxA==}
@@ -5546,65 +5557,65 @@ packages:
       typescript: 4.9.4
     dev: true
 
-  /turbo-darwin-64/1.8.2:
-    resolution: {integrity: sha512-j77U0uOeppENexFsIvvzExADSqMBEeCHnm+6LSNQfaajHSrbUVSTsuD6ZMYHamT6bslc+ZZm21jdecWkwZFBbw==}
+  /turbo-darwin-64/1.8.3:
+    resolution: {integrity: sha512-bLM084Wr17VAAY/EvCWj7+OwYHvI9s/NdsvlqGp8iT5HEYVimcornCHespgJS/yvZDfC+mX9EQkn3V2JmYgGGw==}
     cpu: [x64]
     os: [darwin]
     requiresBuild: true
     dev: true
     optional: true
 
-  /turbo-darwin-arm64/1.8.2:
-    resolution: {integrity: sha512-1NoAvjlwt2wycsAFJouauy9epn9DptSMy6BoGqxJVc4jiibsLepp9qYc4f1/ln0zjd3FR1IvhGOiBfdpqMN7hg==}
+  /turbo-darwin-arm64/1.8.3:
+    resolution: {integrity: sha512-4oZjXtzakopMK110kue3z/hqu3WLv+eDLZOX1NGdo49gqca9BeD8GbH+sXpAp6tqyeuzpss+PIliVYuyt7LgbA==}
     cpu: [arm64]
     os: [darwin]
     requiresBuild: true
     dev: true
     optional: true
 
-  /turbo-linux-64/1.8.2:
-    resolution: {integrity: sha512-TcT3CRYnBYA46kLGGbGC2jDyCEAvMgVpUdpIZGTmod48EKpZaEfVgTkpa4GJde8W68yRFogPZjPVL3yJHFpXSA==}
+  /turbo-linux-64/1.8.3:
+    resolution: {integrity: sha512-uvX2VKotf5PU14FCxJA5iHItPQno2JWzerMd+g3/h/Asay6dvxvtVjc39MQeGT0H5njSvzVKFkT+3/5q8lgOEg==}
     cpu: [x64]
     os: [linux]
     requiresBuild: true
     dev: true
     optional: true
 
-  /turbo-linux-arm64/1.8.2:
-    resolution: {integrity: sha512-Mb9+KBy4YJzPMZ6WGoMzMVZ6EtueCSvOvgmNpVFgkwbtabfBuaBOvN+irtg4RRSWvJQTDTziLABieocEEXZImQ==}
+  /turbo-linux-arm64/1.8.3:
+    resolution: {integrity: sha512-E1p+oH3XKMaPS4rqWhYsL4j2Pzc0d/9P5KU7Kn1kqVLo2T3iRA7n2KVULEieUNE0nTH+aIJPXYXOpqCI5wFJaA==}
     cpu: [arm64]
     os: [linux]
     requiresBuild: true
     dev: true
     optional: true
 
-  /turbo-windows-64/1.8.2:
-    resolution: {integrity: sha512-/+R5ikRrw2w2w38JtNPubGLIQHgUC70m783DI9aPgaM5c8P5D/Y0k6HgjuC/uXgiaz2h3R7p7YWlr+2/E0bqyA==}
+  /turbo-windows-64/1.8.3:
+    resolution: {integrity: sha512-cnzAytHtoLXd0J7aNzRpZFpL/GTjcBmkvAPlbOdf/Pl1iwS4qzGrudZQ+OM1lmLgLIfBPIavsGHBknTwTNib4A==}
     cpu: [x64]
     os: [win32]
     requiresBuild: true
     dev: true
     optional: true
 
-  /turbo-windows-arm64/1.8.2:
-    resolution: {integrity: sha512-s07viz5nXSx4kyiksuPM4FGLRkoaGMaw0BpwFjdRQsl1p+WclUN1IPdokVPKOmFpu5pNCVYlG/raP/mXAEzDCg==}
+  /turbo-windows-arm64/1.8.3:
+    resolution: {integrity: sha512-ulIiItNm2w/zYJdD5/oAzjzNns1IjbpweRzpsE8tLXaWwo6+fnXXkyloUug0IUhcd2k6fJXfoiDZfygqpOVuXg==}
     cpu: [arm64]
     os: [win32]
     requiresBuild: true
     dev: true
     optional: true
 
-  /turbo/1.8.2:
-    resolution: {integrity: sha512-G/uJx6bZK5RwTWHsRN/MP0MvXFznmCaL3MQXdSf+OG/q0o8GE7+yivyyWEplWI1Asc8AEN909A/wlIkoz2FKTg==}
+  /turbo/1.8.3:
+    resolution: {integrity: sha512-zGrkU1EuNFmkq6iky6LcMqD4h0OLE8XysVFxQWRIZbcTNnf0XAycbsbeEyiJpiWeqb7qtg2bVuY9EYcNoNhVuQ==}
     hasBin: true
     requiresBuild: true
     optionalDependencies:
-      turbo-darwin-64: 1.8.2
-      turbo-darwin-arm64: 1.8.2
-      turbo-linux-64: 1.8.2
-      turbo-linux-arm64: 1.8.2
-      turbo-windows-64: 1.8.2
-      turbo-windows-arm64: 1.8.2
+      turbo-darwin-64: 1.8.3
+      turbo-darwin-arm64: 1.8.3
+      turbo-linux-64: 1.8.3
+      turbo-linux-arm64: 1.8.3
+      turbo-windows-64: 1.8.3
+      turbo-windows-arm64: 1.8.3
     dev: true
 
   /type-check/0.3.2:
@@ -5683,8 +5694,8 @@ packages:
     resolution: {integrity: sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA==}
     dev: true
 
-  /ufo/1.0.1:
-    resolution: {integrity: sha512-boAm74ubXHY7KJQZLlXrtMz52qFvpsbOxDcZOnw/Wf+LS4Mmyu7JxmzD4tDLtUQtmZECypJ0FrCz4QIe6dvKRA==}
+  /ufo/1.1.1:
+    resolution: {integrity: sha512-MvlCc4GHrmZdAllBc0iUDowff36Q9Ndw/UzqmEKyrfSzokTd9ZCy1i+IIk5hrYKkjoYVQyNbrw7/F8XJ2rEwTg==}
     dev: false
 
   /uglify-js/3.17.4:
@@ -5695,12 +5706,12 @@ packages:
     dev: true
     optional: true
 
-  /unctx/2.1.1:
-    resolution: {integrity: sha512-RffJlpvLOtolWsn0fxXsuSDfwiWcR6cyuykw2e0+zAggvGW1SesXt9WxIWlWpJhwVCZD/WlxxLqKLS50Q0CkWA==}
+  /unctx/2.1.2:
+    resolution: {integrity: sha512-KK18aLRKe3OlbPyHbXAkIWSU3xK8GInomXfA7fzDMGFXQ1crX1UWrCzKesVXeUyHIayHUrnTvf87IPCKMyeKTg==}
     dependencies:
       acorn: 8.8.2
       estree-walker: 3.0.3
-      magic-string: 0.26.7
+      magic-string: 0.27.0
       unplugin: 1.0.1
     dev: false
 
@@ -5708,20 +5719,20 @@ packages:
     resolution: {integrity: sha512-hEQt0+ZLDVUMhebKxL4x1BTtDY7bavVofhZ9KZ4aI26X9SRaE+Y3m83XUL1UP2jn8ynjndwCCpEHdUG+9pP1Tw==}
     dev: true
 
-  /unimport/1.3.0_rollup@3.12.0:
-    resolution: {integrity: sha512-fOkrdxglsHd428yegH0wPH/6IfaSdDeMXtdRGn6en/ccyzc2aaoxiUTMrJyc6Bu+xoa18RJRPMfLUHEzjz8atw==}
+  /unimport/3.0.3_rollup@3.12.0:
+    resolution: {integrity: sha512-RzQqQiqepF5P13SwBGCe4pLlRnAQlbFuDAaQlSkXiNJDpN2iymtGMSfa75AcVSejgV05Q2aQYt6UhCiy5GuZ2A==}
     dependencies:
       '@rollup/pluginutils': 5.0.2_rollup@3.12.0
       escape-string-regexp: 5.0.0
       fast-glob: 3.2.12
       local-pkg: 0.4.3
-      magic-string: 0.27.0
-      mlly: 1.1.0
+      magic-string: 0.30.0
+      mlly: 1.2.0
       pathe: 1.1.0
-      pkg-types: 1.0.1
+      pkg-types: 1.0.2
       scule: 1.0.0
-      strip-literal: 1.0.0
-      unplugin: 1.0.1
+      strip-literal: 1.0.1
+      unplugin: 1.3.1
     transitivePeerDependencies:
       - rollup
     dev: false
@@ -5766,6 +5777,15 @@ packages:
 
   /unplugin/1.0.1:
     resolution: {integrity: sha512-aqrHaVBWW1JVKBHmGo33T5TxeL0qWzfvjWokObHA9bYmN7eNDkwOxmLjhioHl9878qDFMAaT51XNroRyuz7WxA==}
+    dependencies:
+      acorn: 8.8.2
+      chokidar: 3.5.3
+      webpack-sources: 3.2.3
+      webpack-virtual-modules: 0.5.0
+    dev: false
+
+  /unplugin/1.3.1:
+    resolution: {integrity: sha512-h4uUTIvFBQRxUKS2Wjys6ivoeofGhxzTe2sRWlooyjHXVttcVfV/JiavNd3d4+jty0SVV0dxGw9AkY9MwiaCEw==}
     dependencies:
       acorn: 8.8.2
       chokidar: 3.5.3


### PR DESCRIPTION
No more bootstrap.js!

SSR works! The docs can be build without <ClientOnly>! I belive nuxt works also!

tried to keep the changes to minimal on places.

changed the v-b-toggle to work with events, and now toggle, offcanvas and modal listen to "toggle" event.

As a test I remove bootstrap in playground and only added it's css in link tag in the index.html file.

In bootstrap-vue-next we only need few scss functions/variables/mixins from bootstrap npm package.