### PR TITLE
fix(BButton): isToggle computed property use type of pressedBoolean

### DIFF
--- a/packages/bootstrap-vue-next/src/components/BButton/BButton.vue
+++ b/packages/bootstrap-vue-next/src/components/BButton/BButton.vue
@@ -41,7 +41,7 @@ export default defineComponent({
     disabled: {type: [Boolean, String] as PropType<Booleanish>, default: false},
     href: {type: String, required: false},
     pill: {type: [Boolean, String] as PropType<Booleanish>, default: false},
-    pressed: {type: [Boolean, String] as PropType<Booleanish>, default: false},
+    pressed: {type: [Boolean, String] as PropType<Booleanish>, default: null},
     rel: {type: String, default: undefined},
     size: {type: String as PropType<InputSize>, default: 'md'},
     squared: {type: [Boolean, String] as PropType<Booleanish>, default: false},
@@ -63,7 +63,7 @@ export default defineComponent({
     const squaredBoolean = useBooleanish(toRef(props, 'squared'))
     const loadingBoolean = useBooleanish(toRef(props, 'loading'))
 
-    const isToggle = computed<boolean>(() => pressedBoolean.value === true)
+    const isToggle = computed<boolean>(() => typeof pressedBoolean.value === 'boolean')
     const isButton = computed<boolean>(
       () => props.tag === 'button' && props.href === undefined && props.to === null
     )


### PR DESCRIPTION
# Describe the PR

This PR is a suggestion to resolve issue #973. It will change the `isToggle` computed property to be dependent on the type of `pressedBoolean` instead of its value.

## Small replication

#973

## PR checklist

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix :bug: - `fix(...)`
- [ ] Feature - `feat(...)`
- [ ] ARIA accessibility - `fix(...)`
- [ ] Documentation update - `docs(...)`
- [ ] Other (please describe)

**The PR fulfills these requirements:**

- [ ] Pull request title and all commits follow the [**Conventional Commits**](https://www.conventionalcommits.org/) convention or has an [**override**](https://github.com/googleapis/release-please#how-can-i-fix-release-notes) in this pull request body **This is very important, as the `CHANGELOG` is generated from these messages, and determines the next version type. Pull requests that do not follow conventional commits or do not have an override will be denied**
