### PR TITLE
fix(BButton): fix failing checks from updated pressed prop

### DIFF
--- a/packages/bootstrap-vue-next/src/components/BButton/button.spec.ts
+++ b/packages/bootstrap-vue-next/src/components/BButton/button.spec.ts
@@ -160,6 +160,8 @@ describe('button', () => {
     })
     expect(wrapper.attributes('aria-pressed')).toBe('true')
     await wrapper.setProps({pressed: false})
+    expect(wrapper.attributes('aria-pressed')).toBe('false')
+    await wrapper.setProps({pressed: null})
     expect(wrapper.attributes('aria-pressed')).toBeUndefined()
   })
 
@@ -169,6 +171,8 @@ describe('button', () => {
     })
     expect(wrapper.attributes('autocomplete')).toBe('off')
     await wrapper.setProps({pressed: false})
+    expect(wrapper.attributes('autocomplete')).toBe('off')
+    await wrapper.setProps({pressed: null})
     expect(wrapper.attributes('autocomplete')).toBeUndefined()
   })
 


### PR DESCRIPTION
# Describe the PR

#974 did not include updates in the tests for BButton, this PR will add the changes made to BButton `pressed` prop. This should resolve the failed checks in the PR.

## Small replication

Failed PR checks

## PR checklist

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix :bug: - `fix(...)`
- [ ] Feature - `feat(...)`
- [ ] ARIA accessibility - `fix(...)`
- [ ] Documentation update - `docs(...)`
- [ ] Other (please describe)

**The PR fulfills these requirements:**

- [ ] Pull request title and all commits follow the [**Conventional Commits**](https://www.conventionalcommits.org/) convention or has an [**override**](https://github.com/googleapis/release-please#how-can-i-fix-release-notes) in this pull request body **This is very important, as the `CHANGELOG` is generated from these messages, and determines the next version type. Pull requests that do not follow conventional commits or do not have an override will be denied**
