### PR TITLE
fix(BLink): prefer passed active prop over isActive slot prop from RouterLink

### DIFF
--- a/packages/bootstrap-vue-next/src/components/BButton/BButton.vue
+++ b/packages/bootstrap-vue-next/src/components/BButton/BButton.vue
@@ -98,7 +98,6 @@ export default defineComponent({
       'append': computedLink.value ? props.append : null,
       'activeClass': isBLink.value ? props.activeClass : null,
       'event': isBLink.value ? props.event : null,
-      'exactActiveClass': isBLink.value ? props.exactActiveClass : null,
       'replace': isBLink.value ? props.replace : null,
       'routerComponentName': isBLink.value ? props.routerComponentName : null,
       'routerTag': isBLink.value ? props.routerTag : null,

--- a/packages/bootstrap-vue-next/src/components/BButton/BButton.vue
+++ b/packages/bootstrap-vue-next/src/components/BButton/BButton.vue
@@ -98,7 +98,6 @@ export default defineComponent({
       'append': computedLink.value ? props.append : null,
       'activeClass': isBLink.value ? props.activeClass : null,
       'event': isBLink.value ? props.event : null,
-      'exact': isBLink.value ? props.exact : null,
       'exactActiveClass': isBLink.value ? props.exactActiveClass : null,
       'replace': isBLink.value ? props.replace : null,
       'routerComponentName': isBLink.value ? props.routerComponentName : null,

--- a/packages/bootstrap-vue-next/src/components/BButton/button.spec.ts
+++ b/packages/bootstrap-vue-next/src/components/BButton/button.spec.ts
@@ -381,14 +381,6 @@ describe('button', () => {
     expect($blink.props('event')).toBe('foobar')
   })
 
-  it('has nested prop exactActiveClass when prop exactActiveClass and prop to', () => {
-    const wrapper = mount(BButton, {
-      props: {to: '/abc', exactActiveClass: 'foobar'},
-    })
-    const $blink = wrapper.getComponent(BLink)
-    expect($blink.props('exactActiveClass')).toBe('foobar')
-  })
-
   it('has nested prop routerComponentName when prop routerComponentName and prop to', () => {
     const wrapper = mount(BButton, {
       props: {to: '/abc', routerComponentName: 'foobar'},

--- a/packages/bootstrap-vue-next/src/components/BLink/BLink.vue
+++ b/packages/bootstrap-vue-next/src/components/BLink/BLink.vue
@@ -10,10 +10,7 @@
       :is="routerTag"
       ref="link"
       :href="href"
-      :class="[
-        (isActive || activeBoolean) && activeClass,
-        (isExactActive || exactBoolean) && exactActiveClass,
-      ]"
+      :class="[(activeBoolean ?? isActive) && activeClass, isExactActive && exactActiveClass]"
       v-bind="$attrs"
       @click="navigate"
     >
@@ -39,12 +36,11 @@ import {computed, defineComponent, getCurrentInstance, type PropType, ref, toRef
 import type {RouteLocation, RouteLocationRaw} from 'vue-router'
 
 export const BLINK_PROPS = {
-  active: {type: [Boolean, String] as PropType<Booleanish>, default: false},
+  active: {type: [Boolean, String, undefined] as PropType<Booleanish>, default: undefined},
   activeClass: {type: String, default: 'router-link-active'},
   append: {type: [Boolean, String] as PropType<Booleanish>, default: false},
   disabled: {type: [Boolean, String] as PropType<Booleanish>, default: false},
   event: {type: [String, Array], default: 'click'},
-  exact: {type: [Boolean, String] as PropType<Booleanish>, default: false},
   exactActiveClass: {type: String, default: 'router-link-exact-active'},
   href: {type: String},
   // noPrefetch: {type: [Boolean, String] as PropType<Booleanish>, default: false},
@@ -64,7 +60,6 @@ export default defineComponent({
     const activeBoolean = useBooleanish(toRef(props, 'active'))
     const appendBoolean = useBooleanish(toRef(props, 'append'))
     const disabledBoolean = useBooleanish(toRef(props, 'disabled'))
-    const exactBoolean = useBooleanish(toRef(props, 'exact'))
     const replaceBoolean = useBooleanish(toRef(props, 'replace'))
 
     const instance = getCurrentInstance()
@@ -144,7 +139,6 @@ export default defineComponent({
       appendBoolean,
       disabledBoolean,
       replaceBoolean,
-      exactBoolean,
     }
   },
 })

--- a/packages/bootstrap-vue-next/src/components/BLink/BLink.vue
+++ b/packages/bootstrap-vue-next/src/components/BLink/BLink.vue
@@ -2,7 +2,7 @@
   <component
     :is="tag"
     v-if="tag === 'router-link'"
-    v-slot="{href, navigate, isActive, isExactActive}"
+    v-slot="{href, navigate, isActive}"
     v-bind="routerAttr"
     custom
   >
@@ -10,7 +10,7 @@
       :is="routerTag"
       ref="link"
       :href="href"
-      :class="[(activeBoolean ?? isActive) && activeClass, isExactActive && exactActiveClass]"
+      :class="[(activeBoolean ?? isActive) && activeClass]"
       v-bind="$attrs"
       @click="navigate"
     >
@@ -41,7 +41,6 @@ export const BLINK_PROPS = {
   append: {type: [Boolean, String] as PropType<Booleanish>, default: false},
   disabled: {type: [Boolean, String] as PropType<Booleanish>, default: false},
   event: {type: [String, Array], default: 'click'},
-  exactActiveClass: {type: String, default: 'router-link-exact-active'},
   href: {type: String},
   // noPrefetch: {type: [Boolean, String] as PropType<Booleanish>, default: false},
   // prefetch: {type: [Boolean, String] as PropType<Booleanish>, default: null},

--- a/packages/bootstrap-vue-next/src/components/BListGroup/BListGroupItem.vue
+++ b/packages/bootstrap-vue-next/src/components/BListGroup/BListGroupItem.vue
@@ -29,8 +29,6 @@ interface BListGroupItemProps {
   // append?: Booleanish
   button?: Booleanish
   disabled?: Booleanish
-  // exact?: Booleanish
-  // exactActiveClass?: string
   href?: string
   // noPrefetch?: Booleanish
   // prefetch?: Booleanish

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,7 +12,7 @@ importers:
       husky: 8.0.3
       lint-staged: 13.2.0
       release-please: 15.9.1
-      turbo: 1.8.6
+      turbo: 1.8.8
 
   apps/docs:
     specifiers:
@@ -71,7 +71,6 @@ importers:
     specifiers:
       '@floating-ui/core': ^1.2.4
       '@floating-ui/vue': ^0.2.1
-      '@nuxt/kit': 3.3.1
       '@popperjs/core': ^2.11.6
       '@rushstack/eslint-patch': ^1.2.0
       '@types/node': ^18.15.3
@@ -107,7 +106,6 @@ importers:
       vue-tsc: ^1.0.13
     dependencies:
       '@floating-ui/vue': 0.2.1_vue@3.2.47
-      '@nuxt/kit': 3.3.1_rollup@3.20.2
       '@vueuse/core': 9.13.0_vue@3.2.47
     devDependencies:
       '@floating-ui/core': 1.2.5
@@ -1093,33 +1091,6 @@ packages:
       - supports-color
     dev: true
 
-  /@nuxt/kit/3.3.1_rollup@3.20.2:
-    resolution: {integrity: sha512-zb7/2FUIB1g7nl6K6qozUzfG5uu4yrs9TQjZvpASnPBZ/x1EuJX5k3AA71hMMIVBEX9Adxvh9AuhDEHE5W26Zg==}
-    engines: {node: ^14.18.0 || ^16.10.0 || ^17.0.0 || ^18.0.0 || ^19.0.0}
-    dependencies:
-      '@nuxt/schema': 3.3.1_rollup@3.20.2
-      c12: 1.2.0
-      consola: 2.15.3
-      defu: 6.1.2
-      globby: 13.1.3
-      hash-sum: 2.0.0
-      ignore: 5.2.4
-      jiti: 1.18.2
-      knitwork: 1.0.0
-      lodash.template: 4.5.0
-      mlly: 1.2.0
-      pathe: 1.1.0
-      pkg-types: 1.0.2
-      scule: 1.0.0
-      semver: 7.3.8
-      unctx: 2.1.2
-      unimport: 3.0.4_rollup@3.20.2
-      untyped: 1.3.0
-    transitivePeerDependencies:
-      - rollup
-      - supports-color
-    dev: false
-
   /@nuxt/kit/3.3.2:
     resolution: {integrity: sha512-mHucMYuN/nVJp0p+L6ezzEls8Y1PerAXCJi01lS3Z5ozz+l2OusEfes8EBxWcy3x0C5465ignXCujQs3/LAvnQ==}
     engines: {node: ^14.18.0 || ^16.10.0 || ^17.0.0 || ^18.0.0 || ^19.0.0}
@@ -1186,28 +1157,6 @@ packages:
       - sass
       - supports-color
     dev: true
-
-  /@nuxt/schema/3.3.1_rollup@3.20.2:
-    resolution: {integrity: sha512-E8HWzU43rXzqwDTmWduTLHY4xIwRSAUt1LbpuE9IjZ4uJZq5Mbaj4nfhANNsTQGw2c+O+rL81yzAP3i61LEJDw==}
-    engines: {node: ^14.18.0 || ^16.10.0 || ^17.0.0 || ^18.0.0 || ^19.0.0}
-    dependencies:
-      c12: 1.2.0
-      create-require: 1.1.1
-      defu: 6.1.2
-      hookable: 5.5.2
-      jiti: 1.18.2
-      pathe: 1.1.0
-      pkg-types: 1.0.2
-      postcss-import-resolver: 2.0.0
-      scule: 1.0.0
-      std-env: 3.3.2
-      ufo: 1.1.1
-      unimport: 3.0.4_rollup@3.20.2
-      untyped: 1.3.0
-    transitivePeerDependencies:
-      - rollup
-      - supports-color
-    dev: false
 
   /@nuxt/schema/3.3.2:
     resolution: {integrity: sha512-M2X/iwdX4hct31A7LA2+e41F91VZUXmwS5sZ03G49RnZdEXHMOKBO67e1d+5uxYmRD6eM/EyxWdPVgyLf6wocw==}
@@ -1622,6 +1571,7 @@ packages:
       estree-walker: 2.0.2
       picomatch: 2.3.1
       rollup: 3.20.2
+    dev: true
 
   /@rushstack/eslint-patch/1.2.0:
     resolution: {integrity: sha512-sXo/qW2/pAcmT43VoRKOJbDOfV3cYpq3szSVfIThQXNt+E4DfKj361vaAt3c88U5tPUxzEswam7GW48PJqtKAg==}
@@ -2023,7 +1973,7 @@ packages:
       vite: ^4.0.0
       vue: ^3.2.25
     dependencies:
-      vite: 4.2.1
+      vite: 4.2.1_jbbgimbprg6gc6g7l5xgp24u3u
       vue: 3.2.47
     dev: true
 
@@ -7583,6 +7533,7 @@ packages:
     hasBin: true
     optionalDependencies:
       fsevents: 2.3.2
+    dev: true
 
   /rrweb-cssom/0.6.0:
     resolution: {integrity: sha512-APM0Gt1KoXBz0iIkkdB/kfvGOwC4UuJFeG/c+yV7wSc7q96cG/kJ0HiYCnzivD9SB53cLV1MlHFNfOuPaadYSw==}
@@ -8178,65 +8129,65 @@ packages:
       typescript: 4.9.5
     dev: true
 
-  /turbo-darwin-64/1.8.6:
-    resolution: {integrity: sha512-VlXkQR0TEBAEyBRsvAXBax+fj1EdPKPliwBaCnRLiDUcA/8wYlKte/Kk6ubmj9E0n7U/B4keCxxHiJZqW/5Rqg==}
+  /turbo-darwin-64/1.8.8:
+    resolution: {integrity: sha512-18cSeIm7aeEvIxGyq7PVoFyEnPpWDM/0CpZvXKHpQ6qMTkfNt517qVqUTAwsIYqNS8xazcKAqkNbvU1V49n65Q==}
     cpu: [x64]
     os: [darwin]
     requiresBuild: true
     dev: true
     optional: true
 
-  /turbo-darwin-arm64/1.8.6:
-    resolution: {integrity: sha512-w4L2QLj90ex68UXxTPoqtZPl8mWzc6a1RtPjQhoxAWtZf9T2WXi813dCzYEbVUVC09/DOW/VxZRN7sb2r0KP9A==}
+  /turbo-darwin-arm64/1.8.8:
+    resolution: {integrity: sha512-ruGRI9nHxojIGLQv1TPgN7ud4HO4V8mFBwSgO6oDoZTNuk5ybWybItGR+yu6fni5vJoyMHXOYA2srnxvOc7hjQ==}
     cpu: [arm64]
     os: [darwin]
     requiresBuild: true
     dev: true
     optional: true
 
-  /turbo-linux-64/1.8.6:
-    resolution: {integrity: sha512-eV245jefIhMAZskqQKalFwreC5UEdQcuHcBiWcgUk0py76fbwB7+1HfH5cmeJlb3a1sB6f3H0HHmGPmb34feCA==}
+  /turbo-linux-64/1.8.8:
+    resolution: {integrity: sha512-N/GkHTHeIQogXB1/6ZWfxHx+ubYeb8Jlq3b/3jnU4zLucpZzTQ8XkXIAfJG/TL3Q7ON7xQ8yGOyGLhHL7MpFRg==}
     cpu: [x64]
     os: [linux]
     requiresBuild: true
     dev: true
     optional: true
 
-  /turbo-linux-arm64/1.8.6:
-    resolution: {integrity: sha512-Kiw3nyEvNU6Bpil4zE5FwhasPAOi59R4YdCmjJp0Sen6V9u+/Jij6SWwaoUdATORJLiYQBbhontWBH55B53VDw==}
+  /turbo-linux-arm64/1.8.8:
+    resolution: {integrity: sha512-hKqLbBHgUkYf2Ww8uBL9UYdBFQ5677a7QXdsFhONXoACbDUPvpK4BKlz3NN7G4NZ+g9dGju+OJJjQP0VXRHb5w==}
     cpu: [arm64]
     os: [linux]
     requiresBuild: true
     dev: true
     optional: true
 
-  /turbo-windows-64/1.8.6:
-    resolution: {integrity: sha512-34BkAG9r4nE00xeMeVahaF82h8R6SO+IIOcD60fNr2p+Ch+YcQa+DbEWA/KUj3coUTIiNP5XnRCLRUYADdlxjQ==}
+  /turbo-windows-64/1.8.8:
+    resolution: {integrity: sha512-2ndjDJyzkNslXxLt+PQuU21AHJWc8f6MnLypXy3KsN4EyX/uKKGZS0QJWz27PeHg0JS75PVvhfFV+L9t9i+Yyg==}
     cpu: [x64]
     os: [win32]
     requiresBuild: true
     dev: true
     optional: true
 
-  /turbo-windows-arm64/1.8.6:
-    resolution: {integrity: sha512-4jWUaI7Lmonp2I3x81GruiCYd0aQsG/xDOYhuv9+j2yIgB/UHJFz/P8PWp/nziwPtGpRd/AheDlPzzyd9lWoqw==}
+  /turbo-windows-arm64/1.8.8:
+    resolution: {integrity: sha512-xCA3oxgmW9OMqpI34AAmKfOVsfDljhD5YBwgs0ZDsn5h3kCHhC4x9W5dDk1oyQ4F5EXSH3xVym5/xl1J6WRpUg==}
     cpu: [arm64]
     os: [win32]
     requiresBuild: true
     dev: true
     optional: true
 
-  /turbo/1.8.6:
-    resolution: {integrity: sha512-6IOOaa8ytgjnSCTnp3LKAd2uGBZ/Kmx8ZPlI/YMWuKMUqvkXKLbh+w76ApMgMm+faUqti+QujVWovCu2kY6KuQ==}
+  /turbo/1.8.8:
+    resolution: {integrity: sha512-qYJ5NjoTX+591/x09KgsDOPVDUJfU9GoS+6jszQQlLp1AHrf1wRFA3Yps8U+/HTG03q0M4qouOfOLtRQP4QypA==}
     hasBin: true
     requiresBuild: true
     optionalDependencies:
-      turbo-darwin-64: 1.8.6
-      turbo-darwin-arm64: 1.8.6
-      turbo-linux-64: 1.8.6
-      turbo-linux-arm64: 1.8.6
-      turbo-windows-64: 1.8.6
-      turbo-windows-arm64: 1.8.6
+      turbo-darwin-64: 1.8.8
+      turbo-darwin-arm64: 1.8.8
+      turbo-linux-64: 1.8.8
+      turbo-linux-arm64: 1.8.8
+      turbo-windows-64: 1.8.8
+      turbo-windows-arm64: 1.8.8
     dev: true
 
   /type-check/0.3.2:
@@ -8432,6 +8383,7 @@ packages:
       unplugin: 1.3.1
     transitivePeerDependencies:
       - rollup
+    dev: true
 
   /unist-util-is/4.1.0:
     resolution: {integrity: sha512-ZOQSsnce92GrxSqlnEEseX0gi7GH9zTJZ0p9dtu87WRb/37mMPO2Ilx1s/t9vBHrFhbgweUwb+t7cIn5dxPhZg==}


### PR DESCRIPTION
# Describe the PR

BLink component ignores directly set active prop, when router link passes isActive prop, this causes invalid assignment of active class when nested routes is used.

## Small replication

See tests, or:

Create vue instance with vue-router and nested routes and two BLinks, one heading to default route target and with active prop set to false, and then second to its nested route. After navigation to second route, both BLinks has active class assigned, but the first BLink shouldn't have.

## PR checklist

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix :bug: - `fix(...)`
- [ ] Feature - `feat(...)`
- [ ] ARIA accessibility - `fix(...)`
- [ ] Documentation update - `docs(...)`
- [ ] Other (please describe)

**The PR fulfills these requirements:**

- [x] Pull request title and all commits follow the [**Conventional Commits**](https://www.conventionalcommits.org/) convention or has an [**override**](https://github.com/googleapis/release-please#how-can-i-fix-release-notes) in this pull request body **This is very important, as the `CHANGELOG` is generated from these messages, and determines the next version type. Pull requests that do not follow conventional commits or do not have an override will be denied**
