### PR TITLE
fix(BFormInput): added missing input types to BFormInput

### DIFF
--- a/apps/docs/docs/components/FormInput.md
+++ b/apps/docs/docs/components/FormInput.md
@@ -73,6 +73,10 @@ native browser HTML5 types: `text`, `password`, `email`, `number`, `url`, `tel`,
     'time',
     'range',
     'color',
+    'datetime',
+    'datetime-local',
+    'month',
+    'week',
   ]
 </script>
 ```
@@ -653,6 +657,10 @@ these methods and properties. Support will vary based on input type.
           'time',
           'range',
           'color',
+          'datetime',
+          'datetime-local',
+          'month',
+          'week',
   ]
   const rangeValue = ref('2')
   const rangeValueStep = ref('2')

--- a/apps/docs/docs/reference/types.md
+++ b/apps/docs/docs/reference/types.md
@@ -130,6 +130,10 @@ type InputType =
   | 'time'
   | 'range'
   | 'color'
+  | 'datetime'
+  | 'datetime-local'
+  | 'month'
+  | 'week'
 ```
 
 ## LinkTarget

--- a/apps/playground/src/components/Comps/TFormInput.vue
+++ b/apps/playground/src/components/Comps/TFormInput.vue
@@ -24,6 +24,14 @@
         <b-form-input type="date" />
         <div>type time</div>
         <b-form-input type="time" />
+        <div>type datetime</div>
+        <b-form-input type="datetime" />
+        <div>type datetime-local</div>
+        <b-form-input type="datetime-local" />
+        <div>type month</div>
+        <b-form-input type="month" />
+        <div>type week</div>
+        <b-form-input type="week" />
         <div>type range</div>
         <b-form-input v-model="formInputRangeValue" type="range" min="0" max="5" step="0.5" />
         <div>value : {{ formInputRangeValue }}</div>

--- a/packages/bootstrap-vue-next/src/components/BFormInput/BFormInput.vue
+++ b/packages/bootstrap-vue-next/src/components/BFormInput/BFormInput.vue
@@ -41,6 +41,10 @@ const allowedTypes = [
   'time',
   'range',
   'color',
+  'datetime',
+  'datetime-local',
+  'month',
+  'week',
 ]
 
 export default defineComponent({

--- a/packages/bootstrap-vue-next/src/types/InputType.ts
+++ b/packages/bootstrap-vue-next/src/types/InputType.ts
@@ -10,5 +10,9 @@ type InputType =
   | 'time'
   | 'range'
   | 'color'
+  | 'datetime'
+  | 'datetime-local'
+  | 'month'
+  | 'week'
 
 export default InputType


### PR DESCRIPTION
# Describe the PR

Adds missing input types to BFormInput, like datetime-local, so these are not converted to plain text fields then used. (They were also supported by bootstrap-vue 2)

## PR checklist

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix :bug: - `fix(...)`
- [ ] Feature - `feat(...)`
- [ ] ARIA accessibility - `fix(...)`
- [x] Documentation update - `docs(...)`
- [ ] Other (please describe)

**The PR fulfills these requirements:**

- [x] Pull request title and all commits follow the [**Conventional Commits**](https://www.conventionalcommits.org/) convention or has an [**override**](https://github.com/googleapis/release-please#how-can-i-fix-release-notes) in this pull request body **This is very important, as the `CHANGELOG` is generated from these messages, and determines the next version type. Pull requests that do not follow conventional commits or do not have an override will be denied**
