### PR TITLE
AccordionItem closes when another is opened, add free boolean for opening multiple

### DIFF
--- a/apps/playground/src/components/Comps/TAccordion.vue
+++ b/apps/playground/src/components/Comps/TAccordion.vue
@@ -42,7 +42,8 @@
         </b-accordion>
       </b-col>
       <b-col>
-        <b-accordion free>
+        <b-form-checkbox v-model="isFree">is accordion free</b-form-checkbox>
+        <b-accordion :free="isFree">
           <b-accordion-item id="free1" title="Free accordion Item #1">
             Don't close other items when this one is opened.
           </b-accordion-item>
@@ -62,5 +63,6 @@ import { ref } from 'vue'
 const open = ref(0)
 const openX = ref(true)
 const openId = ref('id1')
+const isFree = ref(true)
 
 </script>

--- a/apps/playground/src/components/Comps/TAccordion.vue
+++ b/apps/playground/src/components/Comps/TAccordion.vue
@@ -31,6 +31,19 @@
           </b-accordion-item>
         </b-accordion>
       </b-col>
+      <b-col>
+        <b-accordion free>
+          <b-accordion-item id="iddddd" title="Free accordion Item #1">
+            Don't close other items when this one is opened.
+          </b-accordion-item>
+          <b-accordion-item title="Free accordion Item #2">
+            Don't close other items when this one is opened.
+          </b-accordion-item>
+          <b-accordion-item title="Free accordion Item #3">
+            Don't close other items when this one is opened.
+          </b-accordion-item>
+        </b-accordion>
+      </b-col>
     </b-row>
   </b-container>
 </template>

--- a/apps/playground/src/components/Comps/TAccordion.vue
+++ b/apps/playground/src/components/Comps/TAccordion.vue
@@ -2,8 +2,18 @@
   <b-container fluid>
     <b-row>
       <b-col>
-        <b-accordion flush>
-          <b-accordion-item id="iddddd" title="Accordion Item #1" visible>
+        <p>
+          <b-button @click="open = open < 2 ? open + 1 : 0"> click for next, now open: {{ open + 1 }}</b-button>
+        </p>
+        <p>
+          <b-form-select :options="[{text:'id1', value: 'id1'}, {text:'id2', value: 'id2'} , {text:'id3', value: 'id3'}]" v-model="openId"/>
+        </p>
+
+
+      </b-col>
+      <b-col>
+        <b-accordion flush v-model="openId">
+          <b-accordion-item id="id1" title="Accordion Item #1" :visible="open === 0" @show="open = 0">
             <strong>This is the first item's accordion body.</strong> It is shown by default, until
             the collapse plugin adds the appropriate classes that we use to style each element.
             These classes control the overall appearance, as well as the showing and hiding via CSS
@@ -12,7 +22,7 @@
             <code>.accordion-body</code>, though the transition does limit overflow.
           </b-accordion-item>
 
-          <b-accordion-item title="Accordion Item #2">
+          <b-accordion-item  id="id2" title="Accordion Item #2" :visible="open === 1" @show="open = 1">
             <strong>This is the second item's accordion body.</strong> It is hidden by default,
             until the collapse plugin adds the appropriate classes that we use to style each
             element. These classes control the overall appearance, as well as the showing and hiding
@@ -21,7 +31,7 @@
             <code>.accordion-body</code>, though the transition does limit overflow.
           </b-accordion-item>
 
-          <b-accordion-item title="Accordion Item #3">
+          <b-accordion-item  id="id3" title="Accordion Item #3" :visible="open === 2" @show="open = 2">
             <strong>This is the third item's accordion body.</strong> It is hidden by default, until
             the collapse plugin adds the appropriate classes that we use to style each element.
             These classes control the overall appearance, as well as the showing and hiding via CSS
@@ -33,13 +43,13 @@
       </b-col>
       <b-col>
         <b-accordion free>
-          <b-accordion-item id="iddddd" title="Free accordion Item #1">
+          <b-accordion-item id="free1" title="Free accordion Item #1">
             Don't close other items when this one is opened.
           </b-accordion-item>
           <b-accordion-item title="Free accordion Item #2">
             Don't close other items when this one is opened.
           </b-accordion-item>
-          <b-accordion-item title="Free accordion Item #3">
+          <b-accordion-item title="Free accordion Item #3" toggle>
             Don't close other items when this one is opened.
           </b-accordion-item>
         </b-accordion>
@@ -47,3 +57,10 @@
     </b-row>
   </b-container>
 </template>
+<script setup lang="ts">
+import { ref } from 'vue'
+const open = ref(0)
+const openX = ref(true)
+const openId = ref('id1')
+
+</script>

--- a/apps/playground/src/components/Comps/TCollapse.vue
+++ b/apps/playground/src/components/Comps/TCollapse.vue
@@ -67,7 +67,7 @@
         </div>
       </b-col>
       <b-col>
-        <b-accordion flush>
+        <b-accordion flush free>
           <b-accordion-item id="iddddd" title="Accordion Item #1" visible>
             Accordion is also using collapse. Openned by visible prop
           </b-accordion-item>

--- a/packages/bootstrap-vue-next/src/components/BAccordion/BAccordion.vue
+++ b/packages/bootstrap-vue-next/src/components/BAccordion/BAccordion.vue
@@ -6,14 +6,16 @@
 
 <script setup lang="ts">
 import type {Booleanish} from '../../types'
-import {computed, provide, ref, toRef} from 'vue'
+import {computed, provide, toRef} from 'vue'
 import {accordionInjectionKey} from '../../utils'
 import {useBooleanish, useId} from '../../composables'
+import {useVModel} from '@vueuse/core'
 
 interface BAccordionProps {
   flush?: Booleanish
   free?: Booleanish
   id?: string
+  modelValue?: string
 }
 
 const props = withDefaults(defineProps<BAccordionProps>(), {
@@ -22,7 +24,8 @@ const props = withDefaults(defineProps<BAccordionProps>(), {
   id: undefined,
 })
 
-const openItem = ref('')
+const emit = defineEmits<(e: 'update:modelValue', value: string) => void>()
+const modelValue = useVModel(props, 'modelValue', emit, {passive: true})
 
 const computedId = useId(toRef(props, 'id'), 'accordion')
 
@@ -35,8 +38,7 @@ const computedClasses = computed(() => ({
 
 if (!freeBoolean.value) {
   provide(accordionInjectionKey, {
-    id: computedId,
-    openItem,
+    openItem: modelValue,
     free: freeBoolean,
   })
 }

--- a/packages/bootstrap-vue-next/src/components/BAccordion/BAccordion.vue
+++ b/packages/bootstrap-vue-next/src/components/BAccordion/BAccordion.vue
@@ -25,6 +25,7 @@ const props = withDefaults(defineProps<BAccordionProps>(), {
 })
 
 const emit = defineEmits<(e: 'update:modelValue', value: string) => void>()
+
 const modelValue = useVModel(props, 'modelValue', emit, {passive: true})
 
 const computedId = useId(toRef(props, 'id'), 'accordion')

--- a/packages/bootstrap-vue-next/src/components/BAccordion/BAccordion.vue
+++ b/packages/bootstrap-vue-next/src/components/BAccordion/BAccordion.vue
@@ -6,7 +6,7 @@
 
 <script setup lang="ts">
 import type {Booleanish} from '../../types'
-import {computed, provide, toRef} from 'vue'
+import {computed, provide, ref, toRef} from 'vue'
 import {accordionInjectionKey} from '../../utils'
 import {useBooleanish, useId} from '../../composables'
 
@@ -22,6 +22,8 @@ const props = withDefaults(defineProps<BAccordionProps>(), {
   id: undefined,
 })
 
+const openItem = ref('')
+
 const computedId = useId(toRef(props, 'id'), 'accordion')
 
 const flushBoolean = useBooleanish(toRef(props, 'flush'))
@@ -34,6 +36,8 @@ const computedClasses = computed(() => ({
 if (!freeBoolean.value) {
   provide(accordionInjectionKey, {
     id: computedId,
+    openItem,
+    free: freeBoolean,
   })
 }
 </script>

--- a/packages/bootstrap-vue-next/src/components/BAccordion/BAccordion.vue
+++ b/packages/bootstrap-vue-next/src/components/BAccordion/BAccordion.vue
@@ -6,7 +6,7 @@
 
 <script setup lang="ts">
 import type {Booleanish} from '../../types'
-import {computed, provide, toRef} from 'vue'
+import {computed, provide, readonly, toRef} from 'vue'
 import {accordionInjectionKey} from '../../utils'
 import {useBooleanish, useId} from '../../composables'
 import {useVModel} from '@vueuse/core'
@@ -38,7 +38,7 @@ const computedClasses = computed(() => ({
 }))
 
 provide(accordionInjectionKey, {
-  openItem: modelValue,
+  openItem: readonly(modelValue),
   free: freeBoolean,
   setOpenItem: (id: string) => {
     modelValue.value = id

--- a/packages/bootstrap-vue-next/src/components/BAccordion/BAccordion.vue
+++ b/packages/bootstrap-vue-next/src/components/BAccordion/BAccordion.vue
@@ -36,10 +36,8 @@ const computedClasses = computed(() => ({
   'accordion-flush': flushBoolean.value,
 }))
 
-if (!freeBoolean.value) {
-  provide(accordionInjectionKey, {
-    openItem: modelValue,
-    free: freeBoolean,
-  })
-}
+provide(accordionInjectionKey, {
+  openItem: modelValue,
+  free: freeBoolean,
+})
 </script>

--- a/packages/bootstrap-vue-next/src/components/BAccordion/BAccordion.vue
+++ b/packages/bootstrap-vue-next/src/components/BAccordion/BAccordion.vue
@@ -40,5 +40,8 @@ const computedClasses = computed(() => ({
 provide(accordionInjectionKey, {
   openItem: modelValue,
   free: freeBoolean,
+  setOpenItem: (id: string) => {
+    modelValue.value = id
+  },
 })
 </script>

--- a/packages/bootstrap-vue-next/src/components/BAccordion/BAccordionItem.vue
+++ b/packages/bootstrap-vue-next/src/components/BAccordion/BAccordionItem.vue
@@ -6,6 +6,12 @@
       class="accordion-collapse"
       v-bind="$attrs"
       :aria-labelledby="`heading${computedId}`"
+      :tag="tag"
+      :toggle="toggle"
+      :horizontal="horizontal"
+      :visible="visible"
+      :is-nav="isNav"
+      v-on="events"
     >
       <template #header="{visible: toggleVisible, toggle}">
         <component :is="headerTag" :id="`heading${computedId}`" class="accordion-header">
@@ -36,17 +42,23 @@ export default {
 <script setup lang="ts">
 import {inject, onMounted, ref, toRef, watch} from 'vue'
 import {useVModel} from '@vueuse/core'
-import {default as BCollapse, type BCollapseEmits, type BCollapseProps} from '../BCollapse.vue'
+import BCollapse from '../BCollapse.vue'
 // import  from '../BCollapse.vue'
-import {accordionInjectionKey} from '../../utils'
+import {accordionInjectionKey, BvTriggerableEvent} from '../../utils'
+
 import {useId} from '../../composables'
 import type {Booleanish} from '../../types'
 
-interface BAccordionItemProps extends BCollapseProps {
+interface BAccordionItemProps {
   id?: string
   title?: string
   modelValue?: Booleanish
   headerTag?: string
+  tag?: string
+  toggle?: Booleanish
+  horizontal?: Booleanish
+  visible?: Booleanish
+  isNav?: Booleanish
 }
 
 const props = withDefaults(defineProps<BAccordionItemProps>(), {
@@ -57,11 +69,25 @@ const props = withDefaults(defineProps<BAccordionItemProps>(), {
   visible: false,
 })
 
-interface BAccordionItemEmits extends BCollapseEmits {
+interface BAccordionItemEmits {
+  (e: 'show', value: BvTriggerableEvent): void
+  (e: 'shown', value: BvTriggerableEvent): void
+  (e: 'hide', value: BvTriggerableEvent): void
+  (e: 'hidden', value: BvTriggerableEvent): void
+  (e: 'hide-prevented'): void
+  (e: 'show-prevented'): void
   (e: 'update:modelValue', value: boolean): void
 }
 
 const emit = defineEmits<BAccordionItemEmits>()
+const events = {
+  'show': (e: BvTriggerableEvent) => emit('show', e),
+  'shown': (e: BvTriggerableEvent) => emit('shown', e),
+  'hide': (e: BvTriggerableEvent) => emit('hide', e),
+  'hidden': (e: BvTriggerableEvent) => emit('hidden', e),
+  'hide-prevented': () => emit('hide-prevented'),
+  'show-prevented': () => emit('show-prevented'),
+}
 
 const modelValue = useVModel(props, 'modelValue', emit, {passive: true})
 

--- a/packages/bootstrap-vue-next/src/components/BAccordion/BAccordionItem.vue
+++ b/packages/bootstrap-vue-next/src/components/BAccordion/BAccordionItem.vue
@@ -34,18 +34,12 @@
   </div>
 </template>
 
-<script lang="ts">
-export default {
-  inheritAttrs: false,
-}
-</script>
 <script setup lang="ts">
 import {inject, onMounted, ref, toRef, watch} from 'vue'
 import {useVModel} from '@vueuse/core'
 import BCollapse from '../BCollapse.vue'
 // import  from '../BCollapse.vue'
 import {accordionInjectionKey, BvTriggerableEvent} from '../../utils'
-
 import {useId} from '../../composables'
 import type {Booleanish} from '../../types'
 
@@ -80,6 +74,7 @@ interface BAccordionItemEmits {
 }
 
 const emit = defineEmits<BAccordionItemEmits>()
+
 const events = {
   'show': (e: BvTriggerableEvent) => emit('show', e),
   'shown': (e: BvTriggerableEvent) => emit('shown', e),
@@ -91,24 +86,31 @@ const events = {
 
 const modelValue = useVModel(props, 'modelValue', emit, {passive: true})
 
-const {openItem, free} = inject(accordionInjectionKey, {
-  openItem: ref(''),
-  free: ref(false),
-})
+const parentData = inject(accordionInjectionKey, null)
 
 const computedId = useId(toRef(props, 'id'), 'accordion_item')
 
 onMounted(() => {
-  if (modelValue.value && !free.value) {
-    openItem.value = computedId.value
+  if (modelValue.value && !parentData?.free.value) {
+    parentData?.setOpenItem(computedId.value)
   }
-  if (!modelValue.value && openItem.value === computedId.value) {
+  if (!modelValue.value && parentData?.openItem.value === computedId.value) {
     modelValue.value = true
   }
 })
 
-watch(openItem, () => (modelValue.value = openItem.value === computedId.value && !free.value))
+watch(
+  () => parentData?.openItem.value,
+  () =>
+    (modelValue.value = parentData?.openItem.value === computedId.value && !parentData?.free.value)
+)
 watch(modelValue, () => {
-  if (modelValue.value && !free.value) openItem.value = computedId.value
+  if (modelValue.value && !parentData?.free.value) parentData?.setOpenItem(computedId.value)
 })
+</script>
+
+<script lang="ts">
+export default {
+  inheritAttrs: false,
+}
 </script>

--- a/packages/bootstrap-vue-next/src/components/BCollapse.vue
+++ b/packages/bootstrap-vue-next/src/components/BCollapse.vue
@@ -180,8 +180,8 @@ if (visibleBoolean.value) {
   show.value = true
 }
 
-watch(visibleBoolean, () => {
-  visibleBoolean.value ? open() : close()
+watch(visibleBoolean, (newval) => {
+  newval ? open() : close()
 })
 
 useEventListener(element, 'bv-toggle', () => {

--- a/packages/bootstrap-vue-next/src/components/BCollapse.vue
+++ b/packages/bootstrap-vue-next/src/components/BCollapse.vue
@@ -21,7 +21,7 @@ import {useEventListener, useVModel} from '@vueuse/core'
 import type {Booleanish} from '../types'
 import {BvTriggerableEvent} from '../utils'
 
-export interface BCollapseProps {
+interface BCollapseProps {
   // appear?: Booleanish
   id?: string
   modelValue?: Booleanish
@@ -31,7 +31,7 @@ export interface BCollapseProps {
   visible?: Booleanish
   isNav?: Booleanish
 }
-export interface BCollapseEmits {
+interface BCollapseEmits {
   (e: 'show', value: BvTriggerableEvent): void
   (e: 'shown', value: BvTriggerableEvent): void
   (e: 'hide', value: BvTriggerableEvent): void

--- a/packages/bootstrap-vue-next/src/components/BCollapse.vue
+++ b/packages/bootstrap-vue-next/src/components/BCollapse.vue
@@ -15,13 +15,13 @@
 </template>
 
 <script setup lang="ts">
-import {computed, nextTick, onMounted, ref, toRef, watchEffect} from 'vue'
+import {computed, nextTick, onMounted, ref, toRef, watch, watchEffect} from 'vue'
 import {useBooleanish, useId} from '../composables'
 import {useEventListener, useVModel} from '@vueuse/core'
 import type {Booleanish} from '../types'
 import {BvTriggerableEvent} from '../utils'
 
-interface BCollapseProps {
+export interface BCollapseProps {
   // appear?: Booleanish
   id?: string
   modelValue?: Booleanish
@@ -30,6 +30,15 @@ interface BCollapseProps {
   horizontal?: Booleanish
   visible?: Booleanish
   isNav?: Booleanish
+}
+export interface BCollapseEmits {
+  (e: 'show', value: BvTriggerableEvent): void
+  (e: 'shown', value: BvTriggerableEvent): void
+  (e: 'hide', value: BvTriggerableEvent): void
+  (e: 'hidden', value: BvTriggerableEvent): void
+  (e: 'hide-prevented'): void
+  (e: 'show-prevented'): void
+  (e: 'update:modelValue', value: boolean): void
 }
 
 const props = withDefaults(defineProps<BCollapseProps>(), {
@@ -42,16 +51,6 @@ const props = withDefaults(defineProps<BCollapseProps>(), {
   visible: false,
   isNav: false,
 })
-
-interface BCollapseEmits {
-  (e: 'show', value: BvTriggerableEvent): void
-  (e: 'shown', value: BvTriggerableEvent): void
-  (e: 'hide', value: BvTriggerableEvent): void
-  (e: 'hidden', value: BvTriggerableEvent): void
-  (e: 'hide-prevented'): void
-  (e: 'show-prevented'): void
-  (e: 'update:modelValue', value: boolean): void
-}
 
 const buildTriggerableEvent = (
   type: string,
@@ -181,7 +180,7 @@ if (visibleBoolean.value) {
   show.value = true
 }
 
-watchEffect(() => {
+watch(visibleBoolean, () => {
   visibleBoolean.value ? open() : close()
 })
 

--- a/packages/bootstrap-vue-next/src/components/BCollapse.vue
+++ b/packages/bootstrap-vue-next/src/components/BCollapse.vue
@@ -22,7 +22,6 @@ import type {Booleanish} from '../types'
 import {BvTriggerableEvent} from '../utils'
 
 interface BCollapseProps {
-  accordion?: string
   // appear?: Booleanish
   id?: string
   modelValue?: Booleanish

--- a/packages/bootstrap-vue-next/src/utils/keys.ts
+++ b/packages/bootstrap-vue-next/src/utils/keys.ts
@@ -46,6 +46,8 @@ export const avatarGroupInjectionKey: InjectionKey<{
 // BAccordion
 export const accordionInjectionKey: InjectionKey<{
   id: Readonly<Ref<string>>
+  openItem: Readonly<Ref<string>>
+  free: Readonly<Ref<boolean>>
 }> = Symbol('accordion')
 
 // BFormCheckboxGroup

--- a/packages/bootstrap-vue-next/src/utils/keys.ts
+++ b/packages/bootstrap-vue-next/src/utils/keys.ts
@@ -45,9 +45,9 @@ export const avatarGroupInjectionKey: InjectionKey<{
 
 // BAccordion
 export const accordionInjectionKey: InjectionKey<{
-  id: Readonly<Ref<string>>
   openItem: Readonly<Ref<string>>
   free: Readonly<Ref<boolean>>
+  setOpenItem: (id: string) => void
 }> = Symbol('accordion')
 
 // BFormCheckboxGroup


### PR DESCRIPTION
As the title says.
fixes #994 
Adds v-modal to BAccordion that is the id of the open accordion. 
Add free booleanish to open multiple
Integrate more with BCollapse