### PR TITLE
docs(home page): Update "Documentation" link to working site

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ This project is still in **alpha version** so there is a lot of work to do. If y
 
 Read our [Contribution Guide](https://github.com/bootstrap-vue/bootstrap-vue-next/blob/main/CONTRIBUTING.md) on how to start helping
 
-[Documentation](https://bootstrap-vue.github.io/bootstrap-vue-next)
+[Documentation](https://github.com/bootstrap-vue/bootstrap-vue-next/tree/main/apps/docs/docs/getting-started)
 
 <h2 align="center">Sponsors</h2>
 


### PR DESCRIPTION
# Describe the PR

Several users have marked an issue for the Documentation site not being working. This turns out to be due to a fault in the static site generation tool, which is going to be replaced in due course.

In the interim other users have pointed out that there is a way for users to see the _current_ documentation without making a local copy of the repo. 

This PR updates the link in the home page to link to that link, which is also within the repo.

## PR checklist

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix :bug: - `fix(...)`
- [ ] Feature - `feat(...)`
- [ ] ARIA accessibility - `fix(...)`
- [x] Documentation update - `docs(...)`
- [ ] Other (please describe)

**The PR fulfills these requirements:**

- [x] Pull request title and all commits follow the [**Conventional Commits**](https://www.conventionalcommits.org/) convention or has an [**override**](https://github.com/googleapis/release-please#how-can-i-fix-release-notes) in this pull request body **This is very important, as the `CHANGELOG` is generated from these messages, and determines the next version type. Pull requests that do not follow conventional commits or do not have an override will be denied**
