### PR TITLE
Fix floating directives unmount error

### DIFF
--- a/packages/bootstrap-vue-next/src/utils/floatingUi.ts
+++ b/packages/bootstrap-vue-next/src/utils/floatingUi.ts
@@ -121,9 +121,12 @@ export const bind = (el: ElementWithPopper, binding: DirectiveBinding) => {
 }
 
 export const unbind = (el: ElementWithPopper) => {
+  const div = el.$__element
   el.$__app?.unmount()
   delete el.$__app
   delete el.$__state
-  el.$__element?.remove()
+  setTimeout(() => {
+    div?.remove()
+  }, 0)
   delete el.$__element
 }


### PR DESCRIPTION
If element is unmounted, the remove() messes vue:n dom handling. Run it in next coroutine.