### PR TITLE
enable fade on tabs, redo tabs only when slot is changed.

### DIFF
--- a/packages/bootstrap-vue-next/src/components/BTabs/BTab.vue
+++ b/packages/bootstrap-vue-next/src/components/BTabs/BTab.vue
@@ -65,10 +65,15 @@ const showSlot = computed<boolean>(() => {
     computedLazy.value && computedLazyOnce.value && lazyRenderCompleted.value
   return computedActive.value || !computedLazy.value || hasLazyRenderedOnce
 })
-
+const show = ref(activeBoolean.value)
+watch(activeBoolean, (active) => {
+  setTimeout(() => {
+    show.value = active
+  }, 0)
+})
 const computedClasses = computed(() => ({
   'active': activeBoolean.value,
-  'show': activeBoolean.value,
+  'show': show.value,
   'card-body': parentData?.card.value && props.noBody === false,
 }))
 


### PR DESCRIPTION
fixes #251 

split the tabs to two, watch for changes in slots.default and recreate the tabs only then. Otherwise we're creating the tabs object on each change and the ID:s change.
Then have computed for the local changes.