### PR TITLE
docs(BCollapse): updated examples and information about collapse slots

### DIFF
--- a/apps/docs/docs/component-references/Collapse.json
+++ b/apps/docs/docs/component-references/Collapse.json
@@ -76,6 +76,37 @@
             "description": "",
             "name": "default",
             "scope": []
+          },
+          {
+            "description": "",
+            "name": "header",
+            "scope": [
+              {
+                "prop": "visible",
+                "type": "Boolean",
+                "description": "Will be `true` if the content is visible. ie: not collapsed"
+              },
+              {
+                "prop": "toggle",
+                "type": "Function",
+                "description": "When called, will toggle the collapse"
+              },
+              {
+                "prop": "open",
+                "type": "Function",
+                "description": "When called, will open the collapse"
+              },
+              {
+                "prop": "close",
+                "type": "Function",
+                "description": "When called, will close the collapse"
+              },
+              {
+                "prop": "id",
+                "type": "String",
+                "description": "The ID of the collapsible element"
+              }
+            ]
           }
         ]
       }

--- a/apps/docs/docs/component-references/Collapse.json
+++ b/apps/docs/docs/component-references/Collapse.json
@@ -75,11 +75,63 @@
           {
             "description": "",
             "name": "default",
-            "scope": []
+            "scope": [
+              {
+                "prop": "visible",
+                "type": "Boolean",
+                "description": "Will be `true` if the content is visible. ie: not collapsed"
+              },
+              {
+                "prop": "toggle",
+                "type": "Function",
+                "description": "When called, will toggle the collapse"
+              },
+              {
+                "prop": "open",
+                "type": "Function",
+                "description": "When called, will open the collapse"
+              },
+              {
+                "prop": "close",
+                "type": "Function",
+                "description": "When called, will close the collapse"
+              }
+            ]
           },
           {
             "description": "",
             "name": "header",
+            "scope": [
+              {
+                "prop": "visible",
+                "type": "Boolean",
+                "description": "Will be `true` if the content is visible. ie: not collapsed"
+              },
+              {
+                "prop": "toggle",
+                "type": "Function",
+                "description": "When called, will toggle the collapse"
+              },
+              {
+                "prop": "open",
+                "type": "Function",
+                "description": "When called, will open the collapse"
+              },
+              {
+                "prop": "close",
+                "type": "Function",
+                "description": "When called, will close the collapse"
+              },
+              {
+                "prop": "id",
+                "type": "String",
+                "description": "The ID of the collapsible element"
+              }
+            ]
+          },
+          {
+            "description": "",
+            "name": "footer",
             "scope": [
               {
                 "prop": "visible",

--- a/apps/docs/docs/components/Collapse.md
+++ b/apps/docs/docs/components/Collapse.md
@@ -312,21 +312,33 @@ at a time.
 
 ## Hiding and showing content in the toggle button based on collapse state
 
-When using the `v-b-toggle` directive, the class `collapsed` will automatically be placed on the
-trigger element when the collapse is closed, and removed when open. You can use this class to
-display or hide content within the toggle via custom CSS.
+<span class="badge bg-info small">New in v0.8.0</span>
+
+The `header` slot can be used to create custom toggles for your collapsible content.
+
+Using the `v-b-toggle` directive to toggle the `<b-collapse>` will still work but the `collapsed` CSS class will no longer be applied to the element with the directive.
+
+The following properties are available for the `header` slot:
+
+| Property  | Type     | Description                           |
+| --------- | -------- | ------------------------------------- |
+| `visible` | Boolean  | Visible state of the collapse         |
+| `toggle`  | Function | When called, will toggle the collapse |
+| `open`    | Function | When called, will open the collapse   |
+| `close`   | Function | When called, will close the collapse  |
+| `id`      | String   | The ID of the collapsible element     |
 
 <ClientOnly>
   <b-card>
     <div>
-      <b-button v-b-toggle:my-collapse>
-        <span class="when-open">Close</span><span class="when-closed">Open</span> My Collapse
-      </b-button>
       <b-collapse id="my-collapse">
+        <template #header="{visible, toggle, id}">
+          <b-button variant="primary" :aria-expanded="visible" :aria-controls="id" @click="toggle">
+              <span v-if="visible">Close</span><span v-else>Open</span> My Collapse
+          </b-button>
+        </template>
         <!-- Content here -->
-        <div class="mt-2">
-            This is data that's being collapsed
-        </div>
+        <div class="mt-2">This is data that's being collapsed</div>
       </b-collapse>
     </div>
   </b-card>
@@ -335,26 +347,17 @@ display or hide content within the toggle via custom CSS.
 ```html
 <b-card>
   <div>
-    <b-button v-b-toggle:my-collapse>
-      <span class="when-open">Close</span><span class="when-closed">Open</span> My Collapse
-    </b-button>
     <b-collapse id="my-collapse">
+      <template #header="{visible, toggle, id}">
+        <b-button variant="primary" :aria-expanded="visible" :aria-controls="id" @click="toggle">
+            <span v-if="visible">Close</span><span v-else>Open</span> My Collapse
+        </b-button>
+      </template>
       <!-- Content here -->
       <div class="mt-2">This is data that's being collapsed</div>
     </b-collapse>
   </div>
 </b-card>
-```
-
-**Example Custom CSS:**
-
-```css
-.collapsed > .when-open {
-  display: none;
-}
-button:not(.collapsed) > .when-closed {
-  display: none;
-}
 ```
 
 ## Optionally scoped default slot

--- a/apps/docs/docs/components/Collapse.md
+++ b/apps/docs/docs/components/Collapse.md
@@ -314,11 +314,11 @@ at a time.
 
 <span class="badge bg-info small">New in v0.8.0</span>
 
-The `header` slot can be used to create custom toggles for your collapsible content.
+The `header` slot can be used to create custom toggles for your collapsible content. The `footer` slot is also available and can be used in the same manner.
 
 Using the `v-b-toggle` directive to toggle the `<b-collapse>` will still work but the `collapsed` CSS class will no longer be applied to the element with the directive.
 
-The following properties are available for the `header` slot:
+The following properties are available for the `header` and `footer` slots:
 
 | Property  | Type     | Description                           |
 | --------- | -------- | ------------------------------------- |


### PR DESCRIPTION
# Describe the PR

I've updated the documentation page for the BCollapse component to include the latest information on how to show/hide content on the collapse toggle, and to advise users that relying on the `v-b-toggle` directive for this will no longer work from 0.8.0 onwards.

The original source for the information was from #1042. I've topped up the component reference with information about the default & footer slots as well.

## PR checklist

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix :bug: - `fix(...)`
- [ ] Feature - `feat(...)`
- [ ] ARIA accessibility - `fix(...)`
- [X] Documentation update - `docs(...)`
- [ ] Other (please describe)

**The PR fulfills these requirements:**

- [X] Pull request title and all commits follow the [**Conventional Commits**](https://www.conventionalcommits.org/) convention or has an [**override**](https://github.com/googleapis/release-please#how-can-i-fix-release-notes) in this pull request body **This is very important, as the `CHANGELOG` is generated from these messages, and determines the next version type. Pull requests that do not follow conventional commits or do not have an override will be denied**
