### PR TITLE
fix: remove b-table item prop mutation by pagination

### DIFF
--- a/packages/bootstrap-vue-next/src/components/BTable/BTable.vue
+++ b/packages/bootstrap-vue-next/src/components/BTable/BTable.vue
@@ -411,7 +411,8 @@ const computedItems = computed(() => {
 
   if (props.perPage !== undefined) {
     const startIndex = (props.currentPage - 1) * props.perPage
-    return items.splice(startIndex, props.perPage)
+    const endIndex = startIndex + props.perPage > items.length ? items.length : startIndex + props.perPage
+    return items.slice(startIndex, endIndex)
   }
   return items
 })


### PR DESCRIPTION
# Describe the PR

If perPage is set and currentPage is changed, prop items will be mutated.
Pagination uses splice to get perPages computedItems and removes them from original items.
This mutates data source.

As a solution, splice is replaced with slice, to geht perPage item range without mutating item prop array.

## Small replication

Reactive items
Reactive currentPage
If currentPage change, items array will be mutated.

## PR checklist

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix :bug: - `fix(...)`
- [ ] Feature - `feat(...)`
- [ ] ARIA accessibility - `fix(...)`
- [ ] Documentation update - `docs(...)`
- [ ] Other (please describe)

**The PR fulfills these requirements:**

- [x] Pull request title and all commits follow the [**Conventional Commits**](https://www.conventionalcommits.org/) convention or has an [**override**](https://github.com/googleapis/release-please#how-can-i-fix-release-notes) in this pull request body **This is very important, as the `CHANGELOG` is generated from these messages, and determines the next version type. Pull requests that do not follow conventional commits or do not have an override will be denied**
