### PR TITLE
fix: add accessibility to b-dropdown and reset show class

### DIFF
--- a/packages/bootstrap-vue-next/src/components/BDropdown/BDropdown.vue
+++ b/packages/bootstrap-vue-next/src/components/BDropdown/BDropdown.vue
@@ -22,9 +22,10 @@
       :variant="variant"
       :size="size"
       :disabled="disabled"
-      :class="toggleClass"
+      :class="[toggleClass, ...[modelValueBoolean ? 'show' : undefined]]"
       class="dropdown-toggle-split dropdown-toggle"
-      aria-expanded="false"
+      :aria-expanded="modelValueBoolean"
+      aria-haspopup="menu"
       @click="onButtonClick"
     >
       <span class="visually-hidden">
@@ -230,6 +231,7 @@ const buttonClasses = computed(() => [
     'dropdown-toggle': !splitBoolean.value,
     'dropdown-toggle-no-caret': noCaretBoolean.value && !splitBoolean.value,
     'w-100': splitBoolean.value && blockBoolean.value,
+    'show': splitBoolean.value ? undefined : modelValueBoolean.value,
   },
 ])
 
@@ -241,7 +243,8 @@ const dropdownMenuClasses = computed(() => [
 ])
 
 const buttonAttr = computed(() => ({
-  'aria-expanded': splitBoolean.value ? undefined : false,
+  'aria-expanded': splitBoolean.value ? undefined : modelValueBoolean.value,
+  'aria-haspopup': splitBoolean.value ? undefined :'menu',
   'href': splitBoolean.value ? props.splitHref : undefined,
   'to': splitBoolean.value && props.splitTo ? props.splitTo : undefined,
 }))


### PR DESCRIPTION
# Describe the PR

1) the accessibility aria-expanded="false" was always on 'false'
2) Add 'show' class when the menu is expended (like old version)

## Small replication

Run the playground and look for Dropdown

## PR checklist

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix :bug: - `fix(...)`
- [x] Feature - `feat(...)`
- [x] ARIA accessibility - `fix(...)`
- [ ] Documentation update - `docs(...)`
- [ ] Other (please describe)

**The PR fulfills these requirements:**

- [ ] Pull request title and all commits follow the [**Conventional Commits**](https://www.conventionalcommits.org/) convention or has an [**override**](https://github.com/googleapis/release-please#how-can-i-fix-release-notes) in this pull request body **This is very important, as the `CHANGELOG` is generated from these messages, and determines the next version type. Pull requests that do not follow conventional commits or do not have an override will be denied**
