### PR TITLE
fix: vueuse may cause CSP error by adding style tag to DOM head

### DIFF
--- a/packages/bootstrap-vue-next/src/components/BModal.vue
+++ b/packages/bootstrap-vue-next/src/components/BModal.vue
@@ -251,6 +251,7 @@ const modalOpen = useSetAttr({
   selector: 'body',
   valueDark: 'modal-open',
   valueLight: '',
+  disableTransition: false,
 })
 
 const element = ref<HTMLElement | null>(null)


### PR DESCRIPTION
# Describe the PR

In order to add 'modal-open' to body, useDark from vueuse is used. useDark uses useColorMode (https://vueuse.org/core/useColorMode/)

However useColorMode will add <style>...</style> to <head> dom which may cause CSP error.

## Small replication

Just open a BModal and in index.html set this :
<meta http-equiv="Content-Security-Policy"
          content="style-src 'self'; ">

## PR checklist

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix :bug: - `fix(...)`
- [ ] Feature - `feat(...)`
- [ ] ARIA accessibility - `fix(...)`
- [ ] Documentation update - `docs(...)`
- [ ] Other (please describe)

**The PR fulfills these requirements:**

- [x] Pull request title and all commits follow the [**Conventional Commits**](https://www.conventionalcommits.org/) convention or has an [**override**](https://github.com/googleapis/release-please#how-can-i-fix-release-notes) in this pull request body **This is very important, as the `CHANGELOG` is generated from these messages, and determines the next version type. Pull requests that do not follow conventional commits or do not have an override will be denied**
