### PR TITLE
B-Table selection behavior does not match the original component

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,9 +1,5 @@
 {
   "private": true,
-  "workspaces": [
-    "packages/*",
-    "apps/*"
-  ],
   "contributors": [
     {
       "name": "aceofwings",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,9 @@
 {
   "private": true,
+  "workspaces": [
+    "packages/*",
+    "apps/*"
+  ],
   "contributors": [
     {
       "name": "aceofwings",

--- a/packages/bootstrap-vue-next/src/components/BTable/BTable.vue
+++ b/packages/bootstrap-vue-next/src/components/BTable/BTable.vue
@@ -474,10 +474,7 @@ const handleRowSelection = (
 ) => {
   if (!selectableBoolean.value) return
 
-  if (ctrlClicked && (props.selectMode === 'range' || props.selectMode === 'multi')) {
-    selectedItems.value.add(row)
-    emit('rowSelected', row)
-  } else if (shiftClicked && props.selectMode === 'range' && selectedItems.value.size > 0) {
+  if (shiftClicked && props.selectMode === 'range' && selectedItems.value.size > 0) {
     const lastSelectedItem = Array.from(selectedItems.value).pop()
     const lastSelectedIndex = computedItems.value.findIndex((i) => i === lastSelectedItem)
     const selectStartIndex = Math.min(lastSelectedIndex, index)
@@ -488,6 +485,14 @@ const handleRowSelection = (
         emit('rowSelected', item)
       }
     })
+  } else if (ctrlClicked && (props.selectMode === 'range' || props.selectMode === 'multi')) {
+    if (selectedItems.value.has(row)) {
+      selectedItems.value.delete(row)
+      emit('rowUnselected', row)
+    } else {
+      selectedItems.value.add(row)
+      emit('rowSelected', row)
+    }
   } else {
     selectedItems.value.forEach((item) => emit('rowUnselected', item))
     selectedItems.value.clear()

--- a/packages/bootstrap-vue-next/src/components/BTable/BTable.vue
+++ b/packages/bootstrap-vue-next/src/components/BTable/BTable.vue
@@ -474,31 +474,25 @@ const handleRowSelection = (
 ) => {
   if (!selectableBoolean.value) return
 
-  if (selectedItems.value.has(row)) {
-    selectedItems.value.delete(row)
-    emit('rowUnselected', row)
+  if (ctrlClicked && (props.selectMode === 'range' || props.selectMode === 'multi')) {
+    selectedItems.value.add(row)
+    emit('rowSelected', row)
+  } else if (shiftClicked && props.selectMode === 'range' && selectedItems.value.size > 0) {
+    const lastSelectedItem = Array.from(selectedItems.value).pop()
+    const lastSelectedIndex = computedItems.value.findIndex((i) => i === lastSelectedItem)
+    const selectStartIndex = Math.min(lastSelectedIndex, index)
+    const selectEndIndex = Math.max(lastSelectedIndex, index)
+    computedItems.value.slice(selectStartIndex, selectEndIndex + 1).forEach((item) => {
+      if (!selectedItems.value.has(item)) {
+        selectedItems.value.add(item)
+        emit('rowSelected', item)
+      }
+    })
   } else {
-    if (props.selectMode === 'range' && selectedItems.value.size > 0 && shiftClicked) {
-      const lastSelectedItem = Array.from(selectedItems.value).pop()
-      const lastSelectedIndex = computedItems.value.findIndex((i) => i === lastSelectedItem)
-      const selectStartIndex = Math.min(lastSelectedIndex, index)
-      const selectEndIndex = Math.max(lastSelectedIndex, index)
-      computedItems.value.slice(selectStartIndex, selectEndIndex + 1).forEach((item) => {
-        if (!selectedItems.value.has(item)) {
-          selectedItems.value.add(item)
-          emit('rowSelected', item)
-        }
-      })
-    } else if ((props.selectMode === 'range' || props.selectMode === 'multi') && ctrlClicked) {
-      selectedItems.value.add(row)
-      emit('rowSelected', row)
-    } else {
-      //behavior for 'single'
-      selectedItems.value.forEach((item) => emit('rowUnselected', item))
-      selectedItems.value.clear()
-      selectedItems.value.add(row)
-      emit('rowSelected', row)
-    }
+    selectedItems.value.forEach((item) => emit('rowUnselected', item))
+    selectedItems.value.clear()
+    selectedItems.value.add(row)
+    emit('rowSelected', row)
   }
 
   notifySelectionEvent()

--- a/packages/bootstrap-vue-next/src/components/BTable/BTable.vue
+++ b/packages/bootstrap-vue-next/src/components/BTable/BTable.vue
@@ -411,7 +411,8 @@ const computedItems = computed(() => {
 
   if (props.perPage !== undefined) {
     const startIndex = (props.currentPage - 1) * props.perPage
-    const endIndex = startIndex + props.perPage > items.length ? items.length : startIndex + props.perPage
+    const endIndex =
+      startIndex + props.perPage > items.length ? items.length : startIndex + props.perPage
     return items.slice(startIndex, endIndex)
   }
   return items
@@ -465,18 +466,18 @@ const notifySelectionEvent = () => {
   emit('selection', Array.from(selectedItems.value))
 }
 
-const handleRowSelection = (row: TableItem, index: number, shiftClicked = false, ctrlClicked = false) => {
+const handleRowSelection = (
+  row: TableItem,
+  index: number,
+  shiftClicked = false,
+  ctrlClicked = false
+) => {
   if (!selectableBoolean.value) return
 
   if (selectedItems.value.has(row)) {
     selectedItems.value.delete(row)
     emit('rowUnselected', row)
   } else {
-    if (props.selectMode === 'single' && selectedItems.value.size > 0) {
-      selectedItems.value.forEach((item) => emit('rowUnselected', item))
-      selectedItems.value.clear()
-    }
-
     if (props.selectMode === 'range' && selectedItems.value.size > 0 && shiftClicked) {
       const lastSelectedItem = Array.from(selectedItems.value).pop()
       const lastSelectedIndex = computedItems.value.findIndex((i) => i === lastSelectedItem)
@@ -488,11 +489,14 @@ const handleRowSelection = (row: TableItem, index: number, shiftClicked = false,
           emit('rowSelected', item)
         }
       })
-    } else if(props.selectMode === 'range' && ctrlClicked) {
+    } else if ((props.selectMode === 'range' || props.selectMode === 'multi') && ctrlClicked) {
       selectedItems.value.add(row)
       emit('rowSelected', row)
-    }else{
+    } else {
+      //behavior for 'single'
+      selectedItems.value.forEach((item) => emit('rowUnselected', item))
       selectedItems.value.clear()
+      selectedItems.value.add(row)
       emit('rowSelected', row)
     }
   }

--- a/packages/bootstrap-vue-next/src/components/BTable/BTable.vue
+++ b/packages/bootstrap-vue-next/src/components/BTable/BTable.vue
@@ -434,7 +434,7 @@ const headerClicked = (field: TableField, event: MouseEvent, isFooter = false) =
 const onRowClick = (row: TableItem, index: number, e: MouseEvent) => {
   emit('rowClicked', row, index, e)
 
-  handleRowSelection(row, index, e.shiftKey)
+  handleRowSelection(row, index, e.shiftKey, e.ctrlKey)
 }
 const onRowDblClick = (row: TableItem, index: number, e: MouseEvent) =>
   emit('rowDblClicked', row, index, e)
@@ -465,7 +465,7 @@ const notifySelectionEvent = () => {
   emit('selection', Array.from(selectedItems.value))
 }
 
-const handleRowSelection = (row: TableItem, index: number, shiftClicked = false) => {
+const handleRowSelection = (row: TableItem, index: number, shiftClicked = false, ctrlClicked = false) => {
   if (!selectableBoolean.value) return
 
   if (selectedItems.value.has(row)) {
@@ -488,8 +488,11 @@ const handleRowSelection = (row: TableItem, index: number, shiftClicked = false)
           emit('rowSelected', item)
         }
       })
-    } else {
+    } else if(props.selectMode === 'range' && ctrlClicked) {
       selectedItems.value.add(row)
+      emit('rowSelected', row)
+    }else{
+      selectedItems.value.clear()
       emit('rowSelected', row)
     }
   }

--- a/packages/bootstrap-vue-next/src/components/BTable/BTable.vue
+++ b/packages/bootstrap-vue-next/src/components/BTable/BTable.vue
@@ -485,11 +485,16 @@ const handleRowSelection = (
         emit('rowSelected', item)
       }
     })
-  } else if (ctrlClicked && (props.selectMode === 'range' || props.selectMode === 'multi')) {
+  } else if (ctrlClicked) {
     if (selectedItems.value.has(row)) {
       selectedItems.value.delete(row)
       emit('rowUnselected', row)
+    } else if (props.selectMode === 'range' || props.selectMode === 'multi') {
+      selectedItems.value.add(row)
+      emit('rowSelected', row)
     } else {
+      selectedItems.value.forEach((item) => emit('rowUnselected', item))
+      selectedItems.value.clear()
       selectedItems.value.add(row)
       emit('rowSelected', row)
     }


### PR DESCRIPTION
# Describe the PR

I noticed that the new B-Table selection behavior when select-mode is set to 'range' does not match the behavior of the original Vue 2 BS4 component. 

**Original B-Table component behavior**
The original Vue 2 BS4 component 'range' mode used to require holding CTRL for multi-select, and shift for range-select. No modifier key used to behave similarly to 'single' mode.

**New behavior**
The new B-Table component only supports shift for multi-select and otherwise defaults to the old CTRL multi-select behavior, leaving no easy way to clear the range selection other than manually unselecting all selected rows.

## PR checklist

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix :bug: - fix behavior to more closely match the behavior that is expected with regards to the original component
- [ ] Feature - `feat(...)`
- [ ] ARIA accessibility - `fix(...)`
- [ ] Documentation update - `docs(...)`
- [ ] Other

BEGIN_COMMIT_OVERRIDE
fix: update btable selection behavior to match original component
END_COMMIT_OVERRIDE