### PR TITLE
fix(BCollapse): auto close only if inside a navbar

### DIFF
--- a/packages/bootstrap-vue-next/src/components/BDropdown/BDropdownItem.vue
+++ b/packages/bootstrap-vue-next/src/components/BDropdown/BDropdownItem.vue
@@ -80,7 +80,6 @@ const navbarData = inject(navbarInjectionKey, null)
 // Pretty sure this emits if tag is not button and is disabled
 const clicked = (e: MouseEvent): void => {
   emit('click', e)
-  //only close, if this component is inside a navbar
   if (navbarData !== null) {
     collapseData?.close?.()
   }

--- a/packages/bootstrap-vue-next/src/components/BDropdown/BDropdownItem.vue
+++ b/packages/bootstrap-vue-next/src/components/BDropdown/BDropdownItem.vue
@@ -17,7 +17,7 @@ import BLink from '../BLink/BLink.vue'
 import {computed, inject, ref, toRef, useAttrs} from 'vue'
 import type {Booleanish, ClassValue, ColorVariant, LinkTarget} from '../../types'
 import {useBooleanish} from '../../composables'
-import {collapseInjectionKey, dropdownInjectionKey} from '../../utils'
+import {collapseInjectionKey, dropdownInjectionKey, navbarInjectionKey} from '../../utils'
 
 interface BDropdownItemProps {
   href?: string
@@ -75,11 +75,15 @@ const componentAttrs = computed(() => ({
 
 const collapseData = inject(collapseInjectionKey, null)
 const dropdownData = inject(dropdownInjectionKey, null)
+const navbarData = inject(navbarInjectionKey, null)
 
 // Pretty sure this emits if tag is not button and is disabled
 const clicked = (e: MouseEvent): void => {
   emit('click', e)
-  collapseData?.close?.()
+  //only close, if this component is inside a navbar
+  if (navbarData !== null) {
+    collapseData?.close?.()
+  }
   dropdownData?.close?.()
 }
 </script>

--- a/packages/bootstrap-vue-next/src/components/BLink/BLink.vue
+++ b/packages/bootstrap-vue-next/src/components/BLink/BLink.vue
@@ -32,7 +32,7 @@
 <script lang="ts">
 import type {Booleanish, LinkTarget} from '../../types'
 import {useBooleanish} from '../../composables'
-import {collapseInjectionKey} from '../../utils'
+import {collapseInjectionKey, navbarInjectionKey} from '../../utils'
 import {computed, defineComponent, getCurrentInstance, inject, type PropType, ref, toRef} from 'vue'
 import type {RouteLocation, RouteLocationRaw} from 'vue-router'
 
@@ -63,8 +63,12 @@ export default defineComponent({
     const disabledBoolean = useBooleanish(toRef(props, 'disabled'))
     const replaceBoolean = useBooleanish(toRef(props, 'replace'))
     const collapseData = inject(collapseInjectionKey, null)
+    const navbarData = inject(navbarInjectionKey, null)
     const closeCollapse = () => {
-      collapseData?.close?.()
+      //only close, if this component is inside a navbar
+      if (navbarData !== null) {
+        collapseData?.close?.()
+      }
     }
 
     const instance = getCurrentInstance()

--- a/packages/bootstrap-vue-next/src/components/BLink/BLink.vue
+++ b/packages/bootstrap-vue-next/src/components/BLink/BLink.vue
@@ -65,7 +65,6 @@ export default defineComponent({
     const collapseData = inject(collapseInjectionKey, null)
     const navbarData = inject(navbarInjectionKey, null)
     const closeCollapse = () => {
-      //only close, if this component is inside a navbar
       if (navbarData !== null) {
         collapseData?.close?.()
       }

--- a/packages/bootstrap-vue-next/src/components/BNavbar/BNavbar.vue
+++ b/packages/bootstrap-vue-next/src/components/BNavbar/BNavbar.vue
@@ -8,9 +8,10 @@
 </template>
 
 <script setup lang="ts">
-import {computed, toRef} from 'vue'
+import {computed, provide, readonly, toRef} from 'vue'
 import type {Booleanish, ColorVariant} from '../../types'
 import {useBooleanish} from '../../composables'
+import {navbarInjectionKey} from '../../utils'
 
 interface Props {
   fixed?: 'top' | 'bottom'
@@ -61,4 +62,8 @@ const computedClasses = computed(() => ({
   [`fixed-${props.fixed}`]: props.fixed !== undefined,
   [`${computedNavbarExpand.value}`]: computedNavbarExpand.value !== undefined,
 }))
+
+provide(navbarInjectionKey, {
+  tag: readonly(toRef(props, 'tag')),
+})
 </script>

--- a/packages/bootstrap-vue-next/src/utils/keys.ts
+++ b/packages/bootstrap-vue-next/src/utils/keys.ts
@@ -107,3 +107,7 @@ export const dropdownInjectionKey: InjectionKey<{
   visible?: Readonly<Ref<boolean>>
   isNav?: Readonly<Ref<boolean>>
 }> = Symbol('collapse')
+
+export const navbarInjectionKey: InjectionKey<{
+  tag?: Readonly<Ref<string>>
+}> = Symbol('navbar')


### PR DESCRIPTION
# Describe the PR

This is my attempt at fixing #1067  and my own issue:
I'm using BCollapse inside a sidebar on the left with a couple of BLinks. The BCollapse should stay open if a BLink is clicked. With 0.8.x the BCollapse now closes automatically.

I wasn't sure which properties to expose from the navbar so I chose tag as some kind of placeholder...

BLink & BDropdownItem now checks if they are inside a navbar and only auto collapse the surrounding BCollapse if so.

Feedback is always welcome :)

## Small replication

If the change is large enough, a small replication can help demonstrate the changes made. This is optional, but can help observe the intended changes. A mentioned issue that contains a replication also works.

## PR checklist

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix :bug: - `fix(...)`
- [ ] Feature - `feat(...)`
- [ ] ARIA accessibility - `fix(...)`
- [ ] Documentation update - `docs(...)`
- [ ] Other (please describe)

**The PR fulfills these requirements:**

- [x] Pull request title and all commits follow the [**Conventional Commits**](https://www.conventionalcommits.org/) convention or has an [**override**](https://github.com/googleapis/release-please#how-can-i-fix-release-notes) in this pull request body **This is very important, as the `CHANGELOG` is generated from these messages, and determines the next version type. Pull requests that do not follow conventional commits or do not have an override will be denied**
